### PR TITLE
Terraform Template/Starter Project for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"mauve.terraform"		
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/Engineering/Templates/Terraform/VSCode/.gitignore
+++ b/Engineering/Templates/Terraform/VSCode/.gitignore
@@ -1,0 +1,12 @@
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# .tfvars files
+*.tfvars
+
+# vs code settings
+**/.vscode/settings.json

--- a/Engineering/Templates/Terraform/VSCode/.vscode/settings.example.json
+++ b/Engineering/Templates/Terraform/VSCode/.vscode/settings.example.json
@@ -1,0 +1,17 @@
+{
+    "terraform" : {
+        "azurerm" : {
+            "tenant_id" : "Tenant to use when executing terraform commands",
+            "subscription_id" : "Subscription to use when executing terraform commands",
+            "client_id" : "Service principal app id to use when executing terraform commands",
+            "client_secret" : "Service principal password to use when executing terraform commands",
+            "backend" : {            
+                "storage_account_name" : "name of the storage account",
+                "access_key" : "primary/secondary access key to the storage account",
+                "resource_group_name" : "resource group to which the storage account is assigned",
+                "container_name" : "storage account blob container name to store the state",
+                "key" : "the name of the blob file to store the state"
+            }
+        }
+    }
+}

--- a/Engineering/Templates/Terraform/VSCode/.vscode/tasks.json
+++ b/Engineering/Templates/Terraform/VSCode/.vscode/tasks.json
@@ -1,0 +1,93 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "terraform init",
+            "type": "shell",
+            "command": "terraform",
+            "problemMatcher": [],
+            "args": [
+                "init",
+                "-backend-config=\"storage_account_name=${config:terraform.azurerm.backend.storage_account_name}\"",
+                "-backend-config=\"container_name=${config:terraform.azurerm.backend.container_name}\"",
+                "-backend-config=\"key=${config:terraform.azurerm.backend.key}\"",
+                "-backend-config=\"access_key=${config:terraform.azurerm.backend.access_key}\"",
+                "-backend-config=\"resource_group_name=${config:terraform.azurerm.backend.resource_group_name}\""
+            ]
+        },
+        {
+            "label": "terraform validate",
+            "type": "shell",
+            "command": "terraform",
+            "problemMatcher": [],
+            "args": [
+                "validate",
+                "-var=env=${config:terraform.tfvars.env}",
+                "-var=org=${config:terraform.tfvars.org}",
+                "-var=location=${config:terraform.tfvars.location}"
+            ]
+        },
+        {
+            "label": "terraform plan",
+            "type": "shell",
+            "command": "terraform",
+            "problemMatcher": [],
+            "args": [
+                "plan",
+                "-var=env=${config:terraform.tfvars.env}",
+                "-var=org=${config:terraform.tfvars.org}",
+                "-var=location=${config:terraform.tfvars.location}"
+            ],
+            "options": {
+                "env": {
+                    "ARM_TENANT_ID" : "${config:terraform.azurerm.tenant_id}",
+                    "ARM_SUBSCRIPTION_ID" : "${config:terraform.azurerm.subscription_id}",
+                    "ARM_CLIENT_ID" : "${config:terraform.azurerm.client_id}",
+                    "ARM_CLIENT_SECRET" : "${config:terraform.azurerm.client_secret}"
+                }
+            }
+        },
+        {
+            "label": "terraform apply",
+            "type": "shell",
+            "command": "terraform",
+            "problemMatcher": [],
+            "args": [
+                "apply",
+                "-var=env=${config:terraform.tfvars.env}",
+                "-var=org=${config:terraform.tfvars.org}",
+                "-var=location=${config:terraform.tfvars.location}"
+            ],
+            "options": {
+                "env": {
+                    "ARM_TENANT_ID" : "${config:terraform.azurerm.tenant_id}",
+                    "ARM_SUBSCRIPTION_ID" : "${config:terraform.azurerm.subscription_id}",
+                    "ARM_CLIENT_ID" : "${config:terraform.azurerm.client_id}",
+                    "ARM_CLIENT_SECRET" : "${config:terraform.azurerm.client_secret}"
+                }
+            }
+        },
+        {
+            "label": "terraform destroy",
+            "type": "shell",
+            "command": "terraform",
+            "problemMatcher": [],
+            "args": [
+                "destroy",
+                "-var=env=${config:terraform.tfvars.env}",
+                "-var=org=${config:terraform.tfvars.org}",
+                "-var=location=${config:terraform.tfvars.location}"
+            ],
+            "options": {
+                "env": {
+                    "ARM_TENANT_ID" : "${config:terraform.azurerm.tenant_id}",
+                    "ARM_SUBSCRIPTION_ID" : "${config:terraform.azurerm.subscription_id}",
+                    "ARM_CLIENT_ID" : "${config:terraform.azurerm.client_id}",
+                    "ARM_CLIENT_SECRET" : "${config:terraform.azurerm.client_secret}"
+                }
+            }
+        }
+    ]
+}

--- a/Engineering/Templates/Terraform/VSCode/README.md
+++ b/Engineering/Templates/Terraform/VSCode/README.md
@@ -1,0 +1,64 @@
+# Terraform VS Code Boostrap Project
+
+The following project provides a template for developing terraform templates within vs code. It contains the following features
+
+1. Execute terraform commands from the task runner (`CTRL+SHIFT+P > Run Tasks`)
+2. Store terraform variable values in workspace and/or settings so that they are not committed to source control.
+
+## Setup/Configuration
+
+The following steps must be completed before vs code will be able to execute terraform commands.
+
+### Install Terraform
+
+Terraform executable should be downloaded [here](https://www.terraform.io/downloads.html) for the appropriate OS. The terraform executable should be added to the PATH variable.
+
+### Create a Service Principal
+
+Terraform currently only supports running as service principal. While you can run as a user, the templates will not be able to obtain any context about the user executing the templates. This can create issues when templates need to grant permissions to resources such as Key Vault. Therefore, it is reccomended to create a service principal with at minimum Contributor role. User Access Administrator role will be needed if the SPN is granting privileges to resources such as Key Vault.
+
+### Create a Remote Backend (Opt)
+
+The vs code tasks will expect that a remote backend is being used to track the terraform state. Prior to running the tasks, a backend must be created. The credentials for the backend will be provided to the settings in the subsequent steps for backend initialization.
+
+### Configure Environment Settings
+
+1. Open up the .vscode\settings.json file.
+2. Paste the following json into the settings.json and update the values accordingly
+
+```js
+    "terraform" : {
+        // the following configures the service principal and subscription to use when executing terraform commands
+        "azurerm" : {
+            "tenant_id" : "Tenant to use when executing terraform commands",
+            "subscription_id" : "Subscription to use when executing terraform commands",
+            "client_id" : "Service principal app id to use when executing terraform commands",
+            "client_secret" : "Service principal password to use when executing terraform commands",
+            "backend" : {
+                "storage_account_name" : "name of the storage account",
+                "access_key" : "primary/secondary access key to the storage account",
+                "resource_group_name" : "resource group to which the storage account is assigned",
+                "container_name" : "storage account blob container name to store the state",
+                "key" : "the name of the blob file to store the state"
+            }
+        },
+        // the values to provide to the terraform template when running commands
+        "tfvars" : {
+            // these are variables required for the provided sample template.
+            // they should be updated to reflect the variables for the real template.
+            "env" : "dev",
+            "org" : "czp",
+            "location" : "eastus"
+        }
+    }
+```
+
+## Run Terraform Commands
+
+Once the environment settings are configured, and the backend has been created, you can begin executing terraform commands. VS Code tasks have been configured to run each of the commonly used terraform commands. These can be accessed via `CTRL+SHIFT+P` > `Tasks: Run Tasks`. Each of these tasks will take its input from what has been configured in `.vscode/settings.json`
+
+- `terraform init`: installs plugins and connects terraform to the remote backend configured in `.vscode/settings.json`
+- `terraform validate`: checks templates for syntax errors
+- `terraform plan`: reports what would be done with apply without actually deploying any resources
+- `terraform apply`: deploys the terraform templates
+- `terraform destroy`: remove anything deployed with the templates. Uses `.vscode/settings.json` to determine what should be destroyed

--- a/Engineering/Templates/Terraform/VSCode/azure-pipelines.yml
+++ b/Engineering/Templates/Terraform/VSCode/azure-pipelines.yml
@@ -1,0 +1,43 @@
+name: terraform ci
+resources:
+- repo: self
+queue:
+  name: Hosted VS2017
+steps:
+- task: AzureCLI@1
+  displayName: 'ensure backend'
+  inputs:
+    azureSubscription: 'Microsoft Azure Subscription'
+    scriptPath: 'create-backend.bat'
+    arguments: '$(glb-org) infrax $(env-name) $(env-location)'
+- task: TerraformInstaller@0
+  displayName: 'terraform install'
+  inputs:
+    terraformVersion: 0.11.11
+- task: TerraformCLI@0
+  displayName: 'terraform init'
+  inputs:
+    command: init
+    backendType: azurerm
+    backendServiceArm: 'Microsoft Azure Subscription'
+    backendAzureRmResourceGroupName: '$(TfBackend.ResourceGroupName)'
+    backendAzureRmStorageAccountName: '$(TfBackend.StorageAccountName)'
+    backendAzureRmContainerName: '$(TfBackend.ContainerName)'
+    backendAzureRmKey: '$(Build.SourceBranchName)'
+- task: TerraformCLI@0
+  displayName: 'terraform validate'
+  inputs:
+    commandOptions: '-var "env=$(env-name)" -var "location=$(env-location)" -var "org=$(glb-org)"'
+    backendServiceArm: 'Microsoft Azure Subscription'
+- task: CopyFiles@2
+  displayName: 'stage artifacts'
+  inputs:
+    Contents: |
+     ?(*.tf|*.vars|*.tfvars|*.bat|*.sh|*.csv|*.yaml)
+     **\?(*.tf|*.vars|*.tfvars)
+     !.terraform\**
+    TargetFolder: '$(build.artifactstagingdirectory)'
+- task: PublishBuildArtifacts@1
+  displayName: 'publish artifacts'
+
+

--- a/Engineering/Templates/Terraform/VSCode/create-backend.bat
+++ b/Engineering/Templates/Terraform/VSCode/create-backend.bat
@@ -1,0 +1,33 @@
+@echo off
+
+set ORG=%1
+set PACKAGE=%2
+set ENV=%3
+set LOCATION=%4
+
+for /f "tokens=2 delims=," %%A in ('findstr /r "^%LOCATION%," "location-suffix-map.csv"') do set LOCATION_SUFFIX=%%A
+
+set RESOURCE_GROUP_NAME=rg-trfrm-%ENV%-%LOCATION_SUFFIX%-%ORG%
+set STORAGE_ACCOUNT_NAME=sttrfrm%ENV%%LOCATION_SUFFIX%%ORG%
+set CONTAINER_NAME=%PACKAGE%
+
+echo Ensuring backend storage account '%STORAGE_ACCOUNT_NAME%' configured for package '%2'
+
+REM create resource group
+call az group create --name %RESOURCE_GROUP_NAME% --location %LOCATION%
+
+REM create storage account
+call az storage account create --resource-group %RESOURCE_GROUP_NAME% --name %STORAGE_ACCOUNT_NAME% --sku Standard_LRS --encryption-services blob
+
+REM get storage account key
+call az storage account keys list --resource-group %RESOURCE_GROUP_NAME% --account-name %STORAGE_ACCOUNT_NAME% --query [0].value -o tsv >storageKey.txt
+set /p ACCOUNT_KEY=<storageKey.txt
+del storageKey.txt
+
+REM create blob container for tf state files
+call az storage container create --name %CONTAINER_NAME% --account-name %STORAGE_ACCOUNT_NAME% --account-key %ACCOUNT_KEY%
+
+REM set azure devops pipeline vars for use in subsequent tasks
+echo ##vso[task.setvariable variable=TfBackend.ResourceGroupName]%RESOURCE_GROUP_NAME%
+echo ##vso[task.setvariable variable=TfBackend.StorageAccountName]%STORAGE_ACCOUNT_NAME%
+echo ##vso[task.setvariable variable=TfBackend.ContainerName]%CONTAINER_NAME%

--- a/Engineering/Templates/Terraform/VSCode/main.tf
+++ b/Engineering/Templates/Terraform/VSCode/main.tf
@@ -1,27 +1,28 @@
-provider "azurerm"{
-    version = "~>1.5"
+provider "azurerm" {
+  version = "~>1.5"
 }
-terraform{
-    backend "azurerm" {
-    }
+
+terraform {
+  backend "azurerm" {}
 }
 
 locals {
-    location_suffixes = {
-        centralus       = "cus"
-        eastus          = "eus"
-        eastus2         = "eus2"
-        westus          = "wus"
-        northcentralus  = "ncus"
-        southcentralus  = "scus"
-        westcentralus   = "wcus"
-        westus2         = "wus2"
-    }
-    location_suffix     = "${local.location_suffixes[var.location]}"
-    suffix              = "-core-${var.env}-${local.location_suffix}-${var.org}"
+  location_suffixes = {
+    centralus = "cus"
+    eastus = "eus"
+    eastus2 = "eus2"
+    westus = "wus"
+    northcentralus = "ncus"
+    southcentralus = "scus"
+    westcentralus = "wcus"
+    westus2 = "wus2"
+  }
+
+  location_suffix = "${local.location_suffixes[var.location]}"
+  suffix = "-core-${var.env}-${local.location_suffix}-${var.org}"
 }
 
 resource "azurerm_resource_group" "rg_core" {
-  name     = "rg${local.suffix}"
+  name = "rg${local.suffix}"
   location = "${var.location}"
 }

--- a/Engineering/Templates/Terraform/VSCode/main.tf
+++ b/Engineering/Templates/Terraform/VSCode/main.tf
@@ -1,0 +1,27 @@
+provider "azurerm"{
+    version = "~>1.5"
+}
+terraform{
+    backend "azurerm" {
+    }
+}
+
+locals {
+    location_suffixes = {
+        centralus       = "cus"
+        eastus          = "eus"
+        eastus2         = "eus2"
+        westus          = "wus"
+        northcentralus  = "ncus"
+        southcentralus  = "scus"
+        westcentralus   = "wcus"
+        westus2         = "wus2"
+    }
+    location_suffix     = "${local.location_suffixes[var.location]}"
+    suffix              = "-core-${var.env}-${local.location_suffix}-${var.org}"
+}
+
+resource "azurerm_resource_group" "rg_core" {
+  name     = "rg${local.suffix}"
+  location = "${var.location}"
+}

--- a/Engineering/Templates/Terraform/VSCode/variables.tf
+++ b/Engineering/Templates/Terraform/VSCode/variables.tf
@@ -1,12 +1,12 @@
 variable "location" {
-    type          = "string"
-    description   = "The name of the target location"
+    type = "string"
+    description = "The name of the target location"
 }
 variable "env" {
-    type        = "string",
+    type = "string",
     description = "The short name of the target env (i.e. dev, staging, or prod)"
 }
 variable "org" {
-    type        = "string",
+    type = "string",
     description = "The short name of the organization"
 }

--- a/Engineering/Templates/Terraform/VSCode/variables.tf
+++ b/Engineering/Templates/Terraform/VSCode/variables.tf
@@ -1,0 +1,12 @@
+variable "location" {
+    type          = "string"
+    description   = "The name of the target location"
+}
+variable "env" {
+    type        = "string",
+    description = "The short name of the target env (i.e. dev, staging, or prod)"
+}
+variable "org" {
+    type        = "string",
+    description = "The short name of the organization"
+}


### PR DESCRIPTION
This is a template for starting a terraform project within vscode. It contains setup for running each of the 5 main terraform commands from the task runner in vscode. We used this with a client to abstract the variable input and for their templates. 

This allows for keeping variable input and backend configuration within the workspace settings; which are not committed to source control. The benefit is that when doing local development devs can keep their settings to themselves safely. Additionally, since the tasks setup all the args for the terraform commands, there's less documentation required for how to run certain commands in their circumstance.

Essentially this is following the npm script pattern to abstract more complex commands + args into shorter aliases.