### PR TITLE
Change VSTS to Azure DevOps

### DIFF
--- a/Engineering/CICD.md
+++ b/Engineering/CICD.md
@@ -18,7 +18,7 @@ For a much deeper understanding of all of these concepts, the books [Continuous 
 
 **Azure Pipelines**
 
-Our tooling at Microsoft has made setting up integration and delivery systems like this easy. If you are unfamiliar with it, take a few moments now to read through [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) (Previously VSTS) and for a practical walkthrough of how this works in practice, one example you can read through is [CI/CD on Kubernetes with VSTS](https://medium.com/@timfpark/application-ci-cd-on-kubernetes-with-visual-studio-team-services-ccacecdea8a5).
+Our tooling at Microsoft has made setting up integration and delivery systems like this easy. If you are unfamiliar with it, take a few moments now to read through [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) (Previously VSTS) and for a practical walkthrough of how this works in practice, one example you can read through is [CI/CD on Kubernetes with Azure DevOps](https://medium.com/@timfpark/application-ci-cd-on-kubernetes-with-visual-studio-team-services-ccacecdea8a5).
 
 **Jenkins**
 

--- a/Engineering/CodeReviews.md
+++ b/Engineering/CodeReviews.md
@@ -10,7 +10,7 @@ Developers working on [CSE](../CSE.md) projects will conduct peer code reviews o
 
 ## Evidence and Measures
 
-Many of these items can be automated or enforced by policy in modern version control and work item tracking systems. Verification of the policies on the master branch in VSTS, for example, may be sufficient evidence that a project team is conducting code reviews.
+Many of these items can be automated or enforced by policy in modern version control and work item tracking systems. Verification of the policies on the master branch in Azure DevOps, for example, may be sufficient evidence that a project team is conducting code reviews.
 
 -   [ ] The master branches in all repositories have branch policies defined in line with the general guidance below.
 -   [ ] All builds produced out of project repositories include appropriate linters, run unit tests, and complete with neither errors nor warnings.
@@ -30,7 +30,7 @@ The goal of code reviews is to identify and remove defects before they can be in
 -   The "readability" and maintainability of the overall design decisions reflected in the code.
 -   The checklist of common errors that the team maintains for each programming language.
 
-The following guidelines are framed prescriptively in terms of VSTS git, but apply equally to other version control and code review environments. Pull request is used as the generic term for a request to commit code to a shared branch.
+The following guidelines are framed prescriptively in terms of Azure DevOps git, but apply equally to other version control and code review environments. Pull request is used as the generic term for a request to commit code to a shared branch.
 
 -   Code review policies should be enforced on the master branch.
     -   Git should be configured to deny commits directly to master, enforcing that all changes are made through topic branch PRs.

--- a/Engineering/ComponentVersioning.md
+++ b/Engineering/ComponentVersioning.md
@@ -53,4 +53,4 @@ Recommendation is to run semver during your CI process to make each build unique
 ## Resources
 - Semantic Versioning: https://semver.org/
 - Versioning in C#: https://docs.microsoft.com/en-us/dotnet/csharp/versioning
-- SemVer Task for VSTS: https://marketplace.visualstudio.com/items?itemName=geeklearningio.gl-vsts-tasks-semver
+- SemVer Task for Azure DevOps: https://marketplace.visualstudio.com/items?itemName=geeklearningio.gl-vsts-tasks-semver

--- a/Engineering/SourceControl.md
+++ b/Engineering/SourceControl.md
@@ -1,5 +1,5 @@
 # Source Control
-There are many different options when working with Source Control. In [CSE](../CSE.md) we use [VSTS](https://csesd.visualstudio.com/_projects) for private repositories and [GitHub](https://github.com/) for public repositories.
+There are many different options when working with Source Control. In [CSE](../CSE.md) we use [Azure DevOps](https://csesd.visualstudio.com/_projects) for private repositories and [GitHub](https://github.com/) for public repositories.
 
 ## Goals
 * Following industry best practice to work in geo-distributed teams which encourage contributions from all across [CSE](../CSE.md) as well as the broader OSS community
@@ -23,7 +23,7 @@ Consistency is crucial, therefore the team has to agree on their approach before
 
 ## Resources
 * [Git](https://git-scm.com/) `--local-branching-on-the-cheap`
-* [VSTS](https://www.visualstudio.com/team-services/)
+* [Azure DevOps](https://www.visualstudio.com/team-services/)
 * [the GitHub Hello World](https://guides.github.com/activities/hello-world/)
 * [CSE Git details](SourceControlDetails.md) provides details and best practices on how to use Git as part of a [CSE](../CSE.md) project.
 * [GitHub - Removing sensitive data from a repository](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)

--- a/Engineering/SourceControl.md
+++ b/Engineering/SourceControl.md
@@ -1,5 +1,5 @@
 # Source Control
-There are many different options when working with Source Control. In [CSE](../CSE.md) we use [Azure DevOps](https://csesd.visualstudio.com/_projects) for private repositories and [GitHub](https://github.com/) for public repositories.
+There are many different options when working with source control. In [CSE](../CSE.md) we use [Azure DevOps](https://csesd.visualstudio.com/_projects) for private repositories and [GitHub](https://github.com/) for public repositories.
 
 ## Goals
 * Following industry best practice to work in geo-distributed teams which encourage contributions from all across [CSE](../CSE.md) as well as the broader OSS community
@@ -23,7 +23,7 @@ Consistency is crucial, therefore the team has to agree on their approach before
 
 ## Resources
 * [Git](https://git-scm.com/) `--local-branching-on-the-cheap`
-* [Azure DevOps](https://www.visualstudio.com/team-services/)
+* [Azure DevOps](https://azure.microsoft.com/en-us/services/devops/)
 * [the GitHub Hello World](https://guides.github.com/activities/hello-world/)
 * [CSE Git details](SourceControlDetails.md) provides details and best practices on how to use Git as part of a [CSE](../CSE.md) project.
 * [GitHub - Removing sensitive data from a repository](https://help.github.com/articles/removing-sensitive-data-from-a-repository/)

--- a/Engineering/SourceControlDetails.md
+++ b/Engineering/SourceControlDetails.md
@@ -59,7 +59,7 @@ git merge topic
          /        
 D---E---F-----------G---H master
 
-Create a PR topic --> master in VSTS and approve using the squash merge option
+Create a PR topic --> master in Azure DevOps and approve using the squash merge option
 ```
 
 # Write good commit comments
@@ -91,13 +91,13 @@ are making this change as opposed to how (the code explains that).
 Are there side effects or other unintuitive consequences of this
 change? Here's the place to explain them.
 
-VSTS understands Markdown, so you can use that sparingly throughout.
+Azure DevOps understands Markdown, so you can use that sparingly throughout.
 
 Further paragraphs come after blank lines.
 
  - Bullet points are okay, too
  - Typically a hyphen or asterisk is used for the bullet, preceded
-   by a single space (no blank lines between them on VSTS)
+   by a single space (no blank lines between them on Azure DevOps)
 
 Put issue references to them at the bottom,
 like this:
@@ -120,7 +120,7 @@ Let's use the following naming conventions for branches:
  * release branches: `release/release_name`
 
 ## Restrict access to default branches
-* In VSTS it's recommended to specify the **minimum number of required reviewers** as well as the **commit strategy** if you want to enforce [squash merging](https://docs.microsoft.com/en-us/vsts/git/merging-with-squash?view=vsts). Here some details on [VSTS branch policies](https://docs.microsoft.com/en-us/vsts/git/branch-policies?view=vsts)
+* In Azure DevOps it's recommended to specify the **minimum number of required reviewers** as well as the **commit strategy** if you want to enforce [squash merging](https://docs.microsoft.com/en-us/vsts/git/merging-with-squash?view=vsts). Here some details on [Azure DevOps branch policies](https://docs.microsoft.com/en-us/vsts/git/branch-policies?view=vsts)
 * In GitHub it's recommended to protect these branches by limiting the push access to reviewers only. Here some details how to [enable branch restrictions in GitHub](https://help.github.com/articles/enabling-branch-restrictions/)
 
 # Release strategy

--- a/Engineering/SourceControlDetails.md
+++ b/Engineering/SourceControlDetails.md
@@ -53,7 +53,7 @@ git checkout master
 git merge topic
 ```
 ### Rebase topic branch before squash merge into master
-[Squash merging](https://docs.microsoft.com/en-us/vsts/git/merging-with-squash?view=vsts) is a merge option that allows you to condense the Git history of topic branches when you complete a pull request. Instead of each commit on `topic` being added to the history of `master`, a squash merge takes all the file changes and adds them to a single new commit on `master`. 
+[Squash merging](https://docs.microsoft.com/en-us/azure/devops/repos/git/merging-with-squash?view=azure-devops) is a merge option that allows you to condense the Git history of topic branches when you complete a pull request. Instead of each commit on `topic` being added to the history of `master`, a squash merge takes all the file changes and adds them to a single new commit on `master`. 
 ```
           A---B---C topic
          /        
@@ -120,7 +120,7 @@ Let's use the following naming conventions for branches:
  * release branches: `release/release_name`
 
 ## Restrict access to default branches
-* In Azure DevOps it's recommended to specify the **minimum number of required reviewers** as well as the **commit strategy** if you want to enforce [squash merging](https://docs.microsoft.com/en-us/vsts/git/merging-with-squash?view=vsts). Here some details on [Azure DevOps branch policies](https://docs.microsoft.com/en-us/vsts/git/branch-policies?view=vsts)
+* In Azure DevOps it's recommended to specify the **minimum number of required reviewers** as well as the **commit strategy** if you want to enforce [squash merging](https://docs.microsoft.com/en-us/azure/devops/repos/git/merging-with-squash?view=azure-devops). Here some details on [Azure DevOps branch policies](https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops)
 * In GitHub it's recommended to protect these branches by limiting the push access to reviewers only. Here some details how to [enable branch restrictions in GitHub](https://help.github.com/articles/enabling-branch-restrictions/)
 
 # Release strategy


### PR DESCRIPTION
Since VSTS is now Azure DevOps, I've update all the markdown that contain `VSTS` and replace it with `Azure DevOps`