### PR TITLE
Emphasize the use of strong typing in Python

### DIFF
--- a/Engineering/CodeReviews/Python.md
+++ b/Engineering/CodeReviews/Python.md
@@ -2,7 +2,7 @@
 
 ## Python Style Guide
 
-[CSE](../CSE.md) developers follow [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+[CSE](../CSE.md) developers follow [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html). Note the use of strong typing throughout. Older versions of python allow you to get away without this but type checking avoids common errors that are tricky to debug. 
 
 ## Linters
 


### PR DESCRIPTION
Given that Python is typically used for rapid prototyping & development, developers frequently forget to use strong typing. However, strong typing can catch a lot of hard-to-debug errors later on down the line. It's included in the linked style guidelines but it's easy to miss so worth emphasizing.