### PR TITLE
Fixes all remaining markdownlint issues

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,3 +1,4 @@
 {
-  "no-trailing-punctuation": false
+  "no-trailing-punctuation": false,
+  "line-length": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-# Adding a new section
+## Adding a new section
 
-## Structure/Pattern
+### Structure/Pattern
 
 Each section consist of the following parts
 
@@ -34,11 +34,11 @@ Each section consist of the following parts
    4. Opportunities for improvement
    5. External Reference Material
 
-## Example Directory Hierarchy
+### Example Directory Hierarchy
 
 The following illustrates how the directory structure could be organized.
 
-```
+```plaintext
 - /continuous-integration
     - README.md (Conceptual)
     - /e2e-testing-in-ci
@@ -56,7 +56,7 @@ The following illustrates how the directory structure could be organized.
         - contoso-ci-pipeline-for-terraform.md
 ```
 
-# Legal Notices
+## Legal Notices
 
 Microsoft and any contributors grant you a license to the Microsoft documentation and other content
 in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),

--- a/SPRINT-STRUCTURE.md
+++ b/SPRINT-STRUCTURE.md
@@ -1,6 +1,6 @@
 # Structure of a Sprint
 
-### Goals
+## Goals
 
 This index structure is intended to accomplish the following goals
 
@@ -8,7 +8,7 @@ This index structure is intended to accomplish the following goals
 2. Provide content in a logical structure which reflects the engineering process.
 3. Extensible hierarchy to allow teams to share deep subject matter expertise.
 
-### A Week In The Life Of....
+## A Week In The Life Of....
 
 This layout structures the playbook content to make it easy day to day to find relevant resources during an Agile sprint.
 
@@ -108,8 +108,8 @@ This layout structures the playbook content to make it easy day to day to find r
     - [Estimation](sprint-planning/estimation/readme.md)
       - Resolving estimation conflicts (two people are sizing differently))
 
-### Assumptions
+## Assumptions
 
 This workflow makes the following assumptions about the development environment
 
-* Team is using git for version control.
+- Team is using git for version control.

--- a/backlog-management/grooming/readme.md
+++ b/backlog-management/grooming/readme.md
@@ -36,4 +36,4 @@ How might one go about running the ceremony? Is there a general pattern that the
 
 ## Useful Links
 
-* Always try and delivery in [Minimal Slices](../minimal-slices.md)
+- Always try and delivery in [Minimal Slices](../minimal-slices.md)

--- a/backlog-management/minimal-slices.md
+++ b/backlog-management/minimal-slices.md
@@ -26,7 +26,9 @@ You divided your feature into smaller User Stories (which in turn will be divide
 3. As a user I have the ability to select build configuration (debug, release)
 4. As a user I have the ability to select target platform (arm, x86, x64)
 5. ...
+
 You also divided your stories into smaller tasks and started sending PRs based on those tasks. E.g. you may have the following tasks for the first user story above:
+
 1. Enable UWP platform on backend
 2. Add `build` button to the UI (build first solution file found)
 3. Add `select solution file` dropdown to the UI

--- a/code-reviews/readme.md
+++ b/code-reviews/readme.md
@@ -30,12 +30,14 @@ We should always aim to have Pull Requests be as small as possible, without losi
 2. It's easier to deploy, at least in terms of a bigger Pull Request. This is aligned with the strategy of release fast and release often.
 3. Minimizes possible conflicts and stale Pull Requests, which are difficult to merge and keep in sync with master either because they're very dynamic or contain refactoring.
 
-However, we should be aware to avoid having Pull Requests that include code without context or very loose coupled. 
+However, we should be aware to avoid having Pull Requests that include code without context or very loose coupled.
 
 There are times where seem a big Pull Request is unavoidable, however, there are some strategies to keep Pull Requests small depending on the "cause" of the ineluctability:
 
 #### Minimum Working Components
+
 #### Layers
+
 #### Feature Flag
 
 ### Reviewee's guidance

--- a/continuous-deployment/secrets-management/readme.md
+++ b/continuous-deployment/secrets-management/readme.md
@@ -1,4 +1,4 @@
-## Secrets Management
+# Secrets Management
 
 Secrets Management refers to the way in which we protect configuration settings and other sensitive data which, if
 made public, would allow unauthorized access to resources. Examples of secrets are usernames, passwords, api keys, SAS
@@ -7,7 +7,7 @@ tokens etc.
 We should assume any repo we work on may be made public at any time and follow the appropriate procedures, even if
 the repo is initially private.
 
-### General Approach
+## General Approach
 
 The general approach is to keep secrets in a separate configuration file during development which is never checked in
 to the repo. Best practice would be to add this file name to the [.gitignore](https://git-scm.com/docs/gitignore) to prevent it being accidentally checked in.
@@ -19,23 +19,23 @@ the Azure CLI to do the same is a useful time-saving utility. See [here](https:/
 *It is best practice to maintain separate secrets configurations for each separate environment that you run. e.g. dev, test, prod, local etc*
 When using a branch-based deployment strategy (e.g. 'master' deploys to production, 'development' deploys to staging, and so forth), a simple way to manage separate secrets configurations on a per-environment basis is described in the [secrets-per-branch recipe](./recipes/azure-devops/secrets-per-branch.md).
 
-### Keeping Secrets Secret
+## Keeping Secrets Secret
 
 It should be obvious, but all the care taken to protect secrets is all for nothing if we aren't careful about how we use secrets once we have them. Primarily: **DON'T LOG SECRETS!!**. Don't put them in logging or reporting. Don't send them to other applications, don't use them in URLs, forms or in any other way other than to make a request to the service that requires that secret.
 
-### Enhanced-Security Applications
+## Enhanced-Security Applications
 
 The techniques outlined below provide 'good' security and a common pattern for a wide range of languages. They rely on
 the fact that Azure keeps application settings (the environment) encrypted until just before your app is run. Encryption keys are regularly rotated. They do *not* prevent secrets from existing in plaintext in memory at runtime. Particularly in garbage collected languages those values may exist for longer than the lifetime of the variable.
 
 *If you are working on an application with enhanced security requirements you should consider using additional techniques to maintain encryption on secrets throughout the application lifetime.*
 
-### Techniques for Secrets Management
+## Techniques for Secrets Management
 
 Below we outline a number of techniques that we can use to make the loading of secrets transparent to the
 developer.
 
-#### C#/.NET
+### C#/.NET
 
 Use the 'file' attribute of the appSettings element to load secrets from a local file. A full description of this attribute can be found [here](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/appsettings/appsettings-element-for-configuration).
 
@@ -64,7 +64,7 @@ Secrets can then be accessed like so:
 
 When running in Azure ConfigurationManager will load these settings from the process environment. No secrets file need to be uploaded to the server and no code needs to be changed.
 
-#### Node
+### Node
 
 Use the [dotenv](https://www.npmjs.com/package/dotenv) package.
 
@@ -80,7 +80,7 @@ let mySecret = process.env("MY_SECRET")
 
 Secrets are loaded into the environment from the .env file if it exists. If not just use existing environment i.e. ApplicationSettings.
 
-#### Python
+### Python
 
 Load config settings into environment manually.
 
@@ -117,7 +117,7 @@ print(os.environ["MY_SECRET"])
 
 Settings file doesn't *have* to be JSON. You might prefer yaml, key=value etc
 
-#### Databricks
+### Databricks
 
 Databricks has the option of using dbutils as a secure way to retrieve credentials and not reveal them within the notebooks running on Databricks
 

--- a/continuous-deployment/secrets-management/recipes/azure-devops/secrets-per-branch.md
+++ b/continuous-deployment/secrets-management/recipes/azure-devops/secrets-per-branch.md
@@ -1,4 +1,4 @@
-## Azure DevOps: managing settings on a per-branch basis
+# Azure DevOps: managing settings on a per-branch basis
 
 When using [Azure DevOps Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) for CI/CD, it is very convenient to leverage the built-in [pipeline variables](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables) for [secrets management](../../readme.md).
 

--- a/continuous-integration/CICD.md
+++ b/continuous-integration/CICD.md
@@ -1,4 +1,4 @@
-## Continuous Integration and Delivery
+# Continuous Integration and Delivery
 
 Continuous Integration is the engineering practice of frequently committing code in a shared repository, ideally several times a day, and performing an automated build on it. These changes are built with other simultaneous changes to the system, which enables early detection of integration issues between multiple developers working on a project. Build breaks due to integration failures are treated as the highest priority issue for all of the developers on a team and generally work stops until they are fixed.
 
@@ -14,29 +14,29 @@ Our expectation is that CI/CD should be used in all of the engineering projects 
 
 For a much deeper understanding of all of these concepts, the books [Continuous Integration](https://www.amazon.com/Continuous-Integration-Improving-Software-Reducing/dp/0321336380) and [Continuous Delivery](https://www.amazon.com/gp/product/0321601912) provide a comprehensive background.
 
-### Tools
+## Tools
 
-**Azure Pipelines**
+### Azure Pipelines
 
 Our tooling at Microsoft has made setting up integration and delivery systems like this easy. If you are unfamiliar with it, take a few moments now to read through [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) (Previously VSTS) and for a practical walkthrough of how this works in practice, one example you can read through is [CI/CD on Kubernetes with VSTS](https://medium.com/@timfpark/application-ci-cd-on-kubernetes-with-visual-studio-team-services-ccacecdea8a5).
 
-**Jenkins**
+### Jenkins
 
 Jenkins is one of the most commonly used tools across the open source community. It is well-known with hundreds of plugins for every build requirement.
 Jenkins is free but requires a dedicated server.
 You can easily create a Jenkins VM using this [template](https://ms.portal.azure.com/#create/azure-oss.jenkinsjenkins)
 
-**TravisCI**
+### TravisCI
 
 Travis CI can be used for open source projects at no cost but developers must purchase an enterprise plan for private projects.
 This service is ideal for validation of PR's on GitHub because it is lightweight and easy to set up with no need for dedicated server setup.
 It also supports a Build matrix feature which allows accelerating the build and testing process by breaking them into parts.
 
-**CircleCI**
+### CircleCI
 
 CircleCI is a free service for open source projects with no dedicated server required. It is also ideal for validation of PR's on GitHub.
 CircleCI also allows workflows, parallelism and splitting your tests across any number of containers with a wide array of packages pre-installed on the build containers.
 
-**AppVeyor**
+### AppVeyor
 
 AppVeyor is another free CI service for open source projects which also supports Windows-based builds.

--- a/continuous-integration/credential-scanning/README.md
+++ b/continuous-integration/credential-scanning/README.md
@@ -1,4 +1,4 @@
-## Credential scanning
+# Credential scanning
 
 Credential scanning is the engineering practice of automatically inspecting a project to ensure that no secrets are included in the project's source code. Secrets include database passwords, storage connection strings, admin logins, service principals, etc. See also [Secrets management](../../continuous-deployment/secrets-management/readme.md).
 

--- a/continuous-integration/credential-scanning/recipes/detect-secrets.md
+++ b/continuous-integration/credential-scanning/recipes/detect-secrets.md
@@ -1,12 +1,12 @@
-## Credential scanning tool suggestion: detect-secrets
+# Credential scanning tool suggestion: detect-secrets
 
-### Background
+## Background
 
 The [detect-secrets](https://github.com/Yelp/detect-secrets) tool is an open source project that uses heuristics and rules to scan for [a wide range](https://github.com/Yelp/detect-secrets#currently-supported-plugins) of secrets. The tool can be extended with custom rules and heuristics via a simple [Python plugin API](https://github.com/Yelp/detect-secrets/blob/a9dff60/detect_secrets/plugins/base.py#L27-L49).
 
 Unlike many credential scanning tools, detect-secrets does not attempt to check a project's entire git history when invoked, but instead only scans the project's current state. This means that the tool runs very quickly which makes it ideal for use in continuous integration pipelines. Additionally, detect-secrets employs the concept of a "baseline file", i.e. a list of known secrets already present in the repository, and can be configured to ignore any of these pre-existing secrets when running. This makes it easy to gradually introduce the tool into a pre-existing project. The baseline file also provides a simple and convenient way of handling false positives: white-list the false positive in the baseline file and it will be ignored on future invocations of the tool.
 
-### Setup
+## Setup
 
 ```sh
 # install system dependencies: diff, jq, python3
@@ -20,7 +20,7 @@ python3 -m pip install detect-secrets
 detect-secrets scan > .secrets.baseline
 ```
 
-### Usage
+## Usage
 
 ```sh
 # backup the list of known secrets

--- a/source-control/git.md
+++ b/source-control/git.md
@@ -40,7 +40,7 @@ Agree if you want a linear or non-linear commit history. There are pros and cons
 
 Merging `topic` into `master`
 
-```
+```bash
   A---B---C topic
  /         \
 D---E---F---G---H master
@@ -96,7 +96,7 @@ This section is merely a tl;dr summary.
 
 Here an example:
 
-```
+```md
 Summarize changes in around 50 characters or less
 
 More detailed explanatory text, if necessary. Wrap it to about 72

--- a/stand-ups/readme.md
+++ b/stand-ups/readme.md
@@ -88,7 +88,7 @@ Stand-up should be held at the same time each day. The meeting time should be mu
 
 ### Schedule Stand-ups for Mid-Morning
 
-```
+```plaintext
              ((((
             ((((
              ))))

--- a/team-agreements/definition-of-done/readme.md
+++ b/team-agreements/definition-of-done/readme.md
@@ -8,12 +8,12 @@ Software Engineering is not just implementing functionality and writing code, bu
 
 Below is an example Done-Done checklist you should follow to ensure everything is done (may vary depending on project/client):
 
-* Is covered by unit and integration tests YES/NO
-* Is continuously tested in each environment YES/NO
-* Does the code coverage meet the minimum threshold YES/NO
-* Is sufficient diagnostic/user telemetry and dashboarding YES/NO
-* Is sufficient public documentation YES/NO
-* Feature owner sign off YES/NO
-* [if applicable] Customer value demo screencast is recorded and sent to the team
+- Is covered by unit and integration tests YES/NO
+- Is continuously tested in each environment YES/NO
+- Does the code coverage meet the minimum threshold YES/NO
+- Is sufficient diagnostic/user telemetry and dashboarding YES/NO
+- Is sufficient public documentation YES/NO
+- Feature owner sign off YES/NO
+- [if applicable] Customer value demo screencast is recorded and sent to the team
 YES/NO
-* [if applicable] Is Relevant architectural review is done YES/NO
+- [if applicable] Is Relevant architectural review is done YES/NO


### PR DESCRIPTION
Fixes markdownlint issues including:
- ensuring `#` for top-level headings
- incrementing subsequent headings by at most one `#`
- changing unordered list asterisks to dashes
- adding whitespace between paragraphs and headings
- setting code fence languages

This change also disables line-length linting, which constituted more than 90% of the lint issues.

Fixes #185