### PR TITLE
Alias markdownlint command in package.json

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -18,5 +18,5 @@ jobs:
         node-version: 12.x
     - name: Run Markdownlint
       run: |
-        npm i -g markdownlint-cli
-        markdownlint "**/*.md"
+        npm i
+        npm run lint

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "lint": "markdownlint \"**/*.md\" --ignore node_modules"
+  },
   "dependencies": {
     "markdownlint-cli": "^0.22.0"
   }


### PR DESCRIPTION
This commit ensures contributors can easily run the same markdownlint command locally as will be run in CI.