### PR TITLE
Adding tools section for reviewing PRs

### DIFF
--- a/code-reviews/README.md
+++ b/code-reviews/README.md
@@ -161,6 +161,7 @@ For more information, see links under [resources](#resources).
 * [Best Kept Secrets of Peer Code Review](https://static1.smartbear.co/smartbear/media/pdfs/best-kept-secrets-of-peer-code-review_redirected.pdf)
 * [A Guide to Code Inspections](http://www.ganssle.com/inspections.pdf)
 * [Defect Removal Effectiveness](https://www.westfallteam.com/sites/default/files/papers/defect_removal_effectiveness.pdf)
+* [Tools](tools.md)
 
 ## Q&A
 

--- a/code-reviews/tools.md
+++ b/code-reviews/tools.md
@@ -1,0 +1,34 @@
+# Code review tools
+
+## Visual Studio Code
+
+### GitHub: [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
+
+Supports GitHub pull request processing inside of VS Code.
+
+1. Open the plugin from the "Activity Bar"
+1. Select "Assigned To Me"
+1. Select a PR
+1. Under "Description" you can chose to "Check Out" the branch and get into "Review Mode" and get a more integrated experience
+
+## Visual Studio
+
+The following extensions can be used to create an integrated code review experience in Visual Studio working with either GitHub or Azure DevOps.
+
+### GitHub: [GitHub Extension for Visual Studio](https://marketplace.visualstudio.com/items?itemName=GitHub.GitHubExtensionforVisualStudio)
+
+Provides extended functionality for working with pull requests on GitHub directly out of Visual Studio.
+
+1. View -> Other Windows -> GitHub
+1. Click on the "Pull Requests" icon in the task bar
+1. Double click on a pending pull request
+
+### Azure DevOps: [Pull Requests for Visual Studio](https://marketplace.visualstudio.com/items?itemName=VSIDEVersionControlMSFT.pr4vs)
+
+Work with pull requests on Azure DevOps directly out of Visual Studio.
+
+1. Open Team Explorer
+1. Click on "Pull Requests"
+1. Double click a pull request - the "Pull Request Details" open
+1. Click on "Checkout" if you want to have the full change locally and have a more integrated experience
+1. Go through the changes and make comments

--- a/code-reviews/tools.md
+++ b/code-reviews/tools.md
@@ -4,12 +4,12 @@
 
 ### GitHub: [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
 
-Supports GitHub pull request processing inside of VS Code.
+Supports processing GitHub pull requests inside VS Code.
 
-1. Open the plugin from the "Activity Bar"
-1. Select "Assigned To Me"
+1. Open the plugin from the **Activity Bar**
+1. Select **Assigned To Me**
 1. Select a PR
-1. Under "Description" you can chose to "Check Out" the branch and get into "Review Mode" and get a more integrated experience
+1. Under **Description** you can chose to **Check Out** the branch and get into **Review Mode** and get a more integrated experience
 
 ## Visual Studio
 
@@ -20,7 +20,7 @@ The following extensions can be used to create an integrated code review experie
 Provides extended functionality for working with pull requests on GitHub directly out of Visual Studio.
 
 1. View -> Other Windows -> GitHub
-1. Click on the "Pull Requests" icon in the task bar
+1. Click on the **Pull Requests** icon in the task bar
 1. Double click on a pending pull request
 
 ### Azure DevOps: [Pull Requests for Visual Studio](https://marketplace.visualstudio.com/items?itemName=VSIDEVersionControlMSFT.pr4vs)
@@ -28,7 +28,7 @@ Provides extended functionality for working with pull requests on GitHub directl
 Work with pull requests on Azure DevOps directly out of Visual Studio.
 
 1. Open Team Explorer
-1. Click on "Pull Requests"
-1. Double click a pull request - the "Pull Request Details" open
-1. Click on "Checkout" if you want to have the full change locally and have a more integrated experience
+1. Click on **Pull Requests**
+1. Double click a pull request - the **Pull Request Details** open
+1. Click on **Checkout** if you want to have the full change locally and have a more integrated experience
 1. Go through the changes and make comments


### PR DESCRIPTION
Adding a section in the readme.md to link to a tools section. Tools can be anything that support the code review process.

I've added tools for VS Code and VS. All of them support the review process out of the VS family and allow to checkout and navigate the code easier than when using the online tools provided by ADO or GitHub.

This is closing #88.