### PR TITLE
Adding initial set of recipes with links

### DIFF
--- a/observability/readme.md
+++ b/observability/readme.md
@@ -86,4 +86,6 @@ Some Examples:
 
 ## Recipes
 
-Links to GitHub posts - Coming soon
+1. Application Insights/ASP.NET - [Github Repo](https://github.com/Azure-Samples/application-insights-aspnet-sample-opentelemetry), [Article](https://devblogs.microsoft.com/aspnet/observability-asp-net-core-apps/).
+
+2. [On-premise Application Insights](https://github.com/c-w/appinsights-on-premises) - A service that is compatiable with Azure App Insights, but stores the data in an in-house database.


### PR DESCRIPTION
Adding two recipes
1. Link to a sample ASP.NET Core/App insights article  and Github repo
2. Link to a Github repo for in-house telemetry using app insights. 

This is by no means an exhaustive list, and links/articles/recipes must be added as they are available

Closes #196 