### PR TITLE
Updating Recipes for Code Analysis

### DIFF
--- a/code-reviews/recipes/Bash.md
+++ b/code-reviews/recipes/Bash.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow [Google's Bash Style Guide](https://google.github.io/styleguide/shell.xml).
 
-## Linting
+## Code Analysis
 
 [CSE](../../CSE.md) projects must check Bash code with [shellcheck](https://github.com/koalaman/shellcheck) as part of the [CI process](../../continuous-integration/readme.md).
 

--- a/code-reviews/recipes/Bash.md
+++ b/code-reviews/recipes/Bash.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow [Google's Bash Style Guide](https://google.github.io/styleguide/shell.xml).
 
-## Code Analysis
+## Code Analysis / Linting
 
 [CSE](../../CSE.md) projects must check Bash code with [shellcheck](https://github.com/koalaman/shellcheck) as part of the [CI process](../../continuous-integration/readme.md).
 

--- a/code-reviews/recipes/CSharp.md
+++ b/code-reviews/recipes/CSharp.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow Microsoft's [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions) and, where applicable, Microsoft's [Secure Coding Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/security/secure-coding-guidelines).
 
-## Code Analysis
+## Code Analysis / Linting
 
 We strongly believe that consistent style increases readability and maintainability of a code base. Hence we are recommending analyzers / linters to enforce consistency and style rules.
 

--- a/code-reviews/recipes/CSharp.md
+++ b/code-reviews/recipes/CSharp.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow Microsoft's [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions) and, where applicable, Microsoft's [Secure Coding Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/security/secure-coding-guidelines).
 
-## Linting
+## Code Analysis
 
 We strongly believe that consistent style increases readability and maintainability of a code base. Hence we are recommending analyzers / linters to enforce consistency and style rules.
 

--- a/code-reviews/recipes/Go.md
+++ b/code-reviews/recipes/Go.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow the [Effective Go](https://golang.org/doc/effective_go.html) Style Guide.
 
-## Code Analysis
+## Code Analysis / Linting
 
 ### go vet
 

--- a/code-reviews/recipes/Go.md
+++ b/code-reviews/recipes/Go.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers follow the [Effective Go](https://golang.org/doc/effective_go.html) Style Guide.
 
-## Linting
+## Code Analysis
 
 ### go vet
 

--- a/code-reviews/recipes/Java.md
+++ b/code-reviews/recipes/Java.md
@@ -4,7 +4,7 @@
 
 [CSE](../../CSE.md) developers generally follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 
-## Code Analysis
+## Code Analysis / Linting
 
 We strongly believe that consistent style increases readability and maintainability of a code base. Hence we are recommending analyzers to enforce consistency and style rules.
 

--- a/code-reviews/recipes/Markdown.md
+++ b/code-reviews/recipes/Markdown.md
@@ -6,7 +6,7 @@
 
 Documentation should both use good markdown syntax to ensure it's properly parsed, and follow good [writing style guidelines](#writing-style) to ensure the document is easy to read and understand.
 
-## Linting
+## Code Analysis
 
 Linting tools exist both for verifying proper markdown syntax as well as grammar and proper English language.
 

--- a/code-reviews/recipes/Markdown.md
+++ b/code-reviews/recipes/Markdown.md
@@ -6,7 +6,7 @@
 
 Documentation should both use good markdown syntax to ensure it's properly parsed, and follow good [writing style guidelines](#writing-style) to ensure the document is easy to read and understand.
 
-## Code Analysis
+## Code Analysis / Linting
 
 Linting tools exist both for verifying proper markdown syntax as well as grammar and proper English language.
 

--- a/code-reviews/recipes/Python.md
+++ b/code-reviews/recipes/Python.md
@@ -8,7 +8,7 @@
 
 Linting should be added to build validation, and both linting and code formatting can be added to your pre-commit hooks and VS Code.
 
-## Linting
+## Code Analysis
 
 The 2 most popular python linters are [Pylint](https://www.pylint.org/) and [Flake8](https://pypi.org/project/flake8/). Both check adherance to `PEP8` but vary a bit in what other rules they check. In general `Pylint` tends to be a bit more stringent and give more false positives but both are good options for linting python code.
 

--- a/code-reviews/recipes/Python.md
+++ b/code-reviews/recipes/Python.md
@@ -8,7 +8,7 @@
 
 Linting should be added to build validation, and both linting and code formatting can be added to your pre-commit hooks and VS Code.
 
-## Code Analysis
+## Code Analysis / Linting
 
 The 2 most popular python linters are [Pylint](https://www.pylint.org/) and [Flake8](https://pypi.org/project/flake8/). Both check adherance to `PEP8` but vary a bit in what other rules they check. In general `Pylint` tends to be a bit more stringent and give more false positives but both are good options for linting python code.
 

--- a/code-reviews/recipes/Terraform.md
+++ b/code-reviews/recipes/Terraform.md
@@ -6,7 +6,7 @@
 
 [CSE](../../CSE.md) projects should check Terraform scripts with automated tools.
 
-## Linting
+## Code Analysis
 
 ### TFLint
 

--- a/code-reviews/recipes/Terraform.md
+++ b/code-reviews/recipes/Terraform.md
@@ -6,7 +6,7 @@
 
 [CSE](../../CSE.md) projects should check Terraform scripts with automated tools.
 
-## Code Analysis
+## Code Analysis / Linting
 
 ### TFLint
 

--- a/code-reviews/recipes/javascript-and-typescript.md
+++ b/code-reviews/recipes/javascript-and-typescript.md
@@ -8,7 +8,7 @@ Using an automated code formatting tool like Prettier enforces a well accepted s
 
 For higher level style guidance not covered by prettier, we follow the [AirBnB Style Guide](https://github.com/airbnb/javascript).
 
-## Code Analysis
+## Code Analysis / Linting
 
 ### eslint
 

--- a/code-reviews/recipes/javascript-and-typescript.md
+++ b/code-reviews/recipes/javascript-and-typescript.md
@@ -8,7 +8,7 @@ Using an automated code formatting tool like Prettier enforces a well accepted s
 
 For higher level style guidance not covered by prettier, we follow the [AirBnB Style Guide](https://github.com/airbnb/javascript).
 
-## Linting
+## Code Analysis
 
 ### eslint
 


### PR DESCRIPTION
Updating different recipes from Linting to Code Analysis.  Note that this includes the Markdown and Terraform recipes which aren't really code.