### PR TITLE
Fix links for code recipes

### DIFF
--- a/code-reviews/recipes/README.md
+++ b/code-reviews/recipes/README.md
@@ -1,9 +1,9 @@
 # Language Specific Guidance
 
-- [Bash](recipes/Bash.md)
-- [C#](recipes/CSharp.md)
-- [Go](recipes/Go.md)
-- [JavaScript and TypeScript](recipes/javascript-and-typescript.md)
-- [Markdown](recipes/Markdown.md)
-- [Python](recipes/Python.md)
-- [Terraform](recipes/Terraform.md)
+- [Bash](./Bash.md)
+- [C#](./CSharp.md)
+- [Go](./Go.md)
+- [JavaScript and TypeScript](./javascript-and-typescript.md)
+- [Markdown](./Markdown.md)
+- [Python](./Python.md)
+- [Terraform](./Terraform.md)


### PR DESCRIPTION
Links got broken when restructuring the code-review section.

Close #264 