### PR TITLE
Adding dev containers reference to the CI playbook guidance

### DIFF
--- a/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
@@ -1,0 +1,67 @@
+FROM golang:1.13-stretch
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG TERRAFORM_VERSION=0.12.24
+ARG TFLINT_VERSION=0.15.3
+ARG TERRAFORM_PROVIDER_AZUREDEVOPS_NAME=terraform-provider-azuredevops
+ARG TERRAFORM_PROVIDER_AZUREDEVOPS_REPO=https://github.com/microsoft/terraform-provider-azuredevops.git
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs), unzip installed
+    && apt-get -y install git procps lsb-release unzip \
+    # Install Editor
+    && apt-get install vim -y \
+    # Install Terraform, tflint
+    && mkdir -p /tmp/docker-downloads \
+    && curl -sSL -o /tmp/docker-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && unzip /tmp/docker-downloads/terraform.zip \
+    && mv terraform /usr/local/bin \
+    && curl -sSL -o /tmp/docker-downloads/tflint.zip https://github.com/wata727/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip \
+    && unzip /tmp/docker-downloads/tflint.zip \
+    && mv tflint /usr/local/bin \
+    && cd ~ \ 
+    && rm -rf /tmp/docker-downloads \
+    # Install the Azure CLI
+    && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable go modules
+ENV GO111MODULE=on
+
+# Install Go tools
+RUN \
+    # --> Delve for debugging
+    go get github.com/go-delve/delve/cmd/dlv@v1.4.0 \
+    # --> Go language server
+    && go get golang.org/x/tools/gopls@v0.3.4 \
+    # --> GolangCI-lint
+    && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sed 's/tar -/tar --no-same-owner -/g' | sh -s -- -b $(go env GOPATH)/bin \
+    # --> Go-outline for extracting a JSON representation of the declarations in a Go source file
+    && go get -v github.com/ramya-rao-a/go-outline \
+    #
+    # Clean up
+    && rm -rf /go/src/ && rm -rf /go/pkg
+
+# Install AzDO terraform provider
+RUN git clone ${TERRAFORM_PROVIDER_AZUREDEVOPS_REPO}
+ADD . ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}
+RUN (cd ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME} && make build) \
+    && rm -rf ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}
+
+# Git command prompt
+RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1 \
+    && echo "if [ -f \"$HOME/.bash-git-prompt/gitprompt.sh\" ]; then GIT_PROMPT_ONLY_IN_REPO=1 && source $HOME/.bash-git-prompt/gitprompt.sh; fi" >> "/root/.bashrc"
+
+# Add alias
+RUN echo "alias tf=terraform" >> "/root/.bashrc"
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- "v0.132.1"

--- a/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update \
     && apt-get -y install git procps lsb-release unzip \
     # Install Editor
     && apt-get install vim -y \
+    # Install JQ
+    && apt-get install jq -y \
     # Install Terraform, tflint
     && mkdir -p /tmp/docker-downloads \
     && curl -sSL -o /tmp/docker-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
@@ -50,9 +52,9 @@ RUN \
 
 # Install AzDO terraform provider
 RUN git clone ${TERRAFORM_PROVIDER_AZUREDEVOPS_REPO}
-ADD . ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}
-RUN (cd ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME} && make build) \
-    && rm -rf ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}
+RUN ./${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}/scripts/build.sh
+RUN ./${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}/scripts/local-install.sh
+RUN rm -rf ${TERRAFORM_PROVIDER_AZUREDEVOPS_NAME}
 
 # Git command prompt
 RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prompt --depth=1 \
@@ -60,8 +62,3 @@ RUN git clone https://github.com/magicmonty/bash-git-prompt.git ~/.bash-git-prom
 
 # Add alias
 RUN echo "alias tf=terraform" >> "/root/.bashrc"
-
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
-
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- "v0.132.1"

--- a/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+	"name": "Dev Dockerfile",
+	"dockerFile": "Dockerfile",
+	"context": "..",
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		// Enable go debugger
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined",
+		// Enable SSH for git
+		"-v",
+		"${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro"
+	],
+	"postCreateCommand": "mkdir -p /root/.ssh && cp -r /root/.ssh-localhost/* /root/.ssh && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*",
+	"settings": {
+        "files.eol": "\n",
+        "terraform.indexing": {
+			"enabled": false,
+			"liveIndexing": false
+		},
+		"go.gopath": "/go",
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.useLanguageServer": true,
+		"go.autocompleteUnimportedPackages": true,
+		"go.gotoSymbol.includeImports": true,
+		"go.gotoSymbol.includeGoroot": true,
+		"go.toolsEnvVars": {
+			"GO111MODULE": "on"
+		},
+		"go.lintFlags": [
+			"--fast"
+		],
+		"go.testFlags": [
+			"-v",
+			"-tags=all"
+		],
+		"go.testEnvVars": {
+			"TF_ACC": "1"
+		},
+		"go.testEnvFile": "${workspaceFolder}/.env",
+		"[go]": {
+			"editor.formatOnSave": true,
+			"editor.codeActionsOnSave": {
+				"source.organizeImports": true
+			}
+		},
+		"gopls": {
+			"usePlaceholders": true, // add parameter placeholders when completing a function
+			// Experimental settings
+			"completeUnimported": true, // autocomplete unimported packages
+			"deepCompletion": true // enable deep completion
+		},
+	},
+	"extensions": [
+        "ms-vscode.go",
+        "ms-azuretools.vscode-azureterraform",
+		"ms-vscode.azurecli",
+		"ms-azuretools.vscode-docker"
+	]
+}

--- a/continuous-integration/readme.md
+++ b/continuous-integration/readme.md
@@ -70,6 +70,7 @@ An automated build should encompass the following principles:
   - We encourage maintaining a consistent developer experience for all team members. There should be a central automated manifest / process that streamlines the installation and setup of any software dependencies. This way developers can replicate the same build environment locally as the one running on a CI server.
   - Build automation scripts often require specific software packages and version pre-installed within the runtime environment of the OS. This presents some challenges as build processes typically version lock these dependencies.
   - All developers on the team should be able to emulate the build environment from their local desktop regardless of their OS.
+  - For projects using VS Code, leveraging [Dev Containers](https://code.visualstudio.com/docs/remote/containers) can really help standardize the local developer experience across the team. Feel free to reuse any one of our technology stack themed dev container from the [container gallery](./devcontainers/). Contributions to the gallery are always welcomed.
   - Well established software packaging tools like Docker, Maven, npm, etc should be considered when designing your build automation tool chain.
 - [ ] **Document local setup**
   - The setup process for setting up a local build environment should be well documented and easy for developers to follow.

--- a/continuous-integration/readme.md
+++ b/continuous-integration/readme.md
@@ -70,7 +70,7 @@ An automated build should encompass the following principles:
   - We encourage maintaining a consistent developer experience for all team members. There should be a central automated manifest / process that streamlines the installation and setup of any software dependencies. This way developers can replicate the same build environment locally as the one running on a CI server.
   - Build automation scripts often require specific software packages and version pre-installed within the runtime environment of the OS. This presents some challenges as build processes typically version lock these dependencies.
   - All developers on the team should be able to emulate the build environment from their local desktop regardless of their OS.
-  - For projects using VS Code, leveraging [Dev Containers](https://code.visualstudio.com/docs/remote/containers) can really help standardize the local developer experience across the team. Feel free to reuse any one of our technology stack themed dev container(s) from the [container gallery](./devcontainers/). Contributions to the gallery are always welcomed.
+  - For projects using VS Code, leveraging [Dev Containers](https://stuartleeks.com/posts/vscode-devcontainers/) can really help standardize the local developer experience across the team. Feel free to reuse any one of our technology stack themed dev container(s) from the [container gallery](./devcontainers/). Contributions to the gallery are always welcomed.
   - Well established software packaging tools like Docker, Maven, npm, etc should be considered when designing your build automation tool chain.
 - [ ] **Document local setup**
   - The setup process for setting up a local build environment should be well documented and easy for developers to follow.

--- a/continuous-integration/readme.md
+++ b/continuous-integration/readme.md
@@ -70,7 +70,7 @@ An automated build should encompass the following principles:
   - We encourage maintaining a consistent developer experience for all team members. There should be a central automated manifest / process that streamlines the installation and setup of any software dependencies. This way developers can replicate the same build environment locally as the one running on a CI server.
   - Build automation scripts often require specific software packages and version pre-installed within the runtime environment of the OS. This presents some challenges as build processes typically version lock these dependencies.
   - All developers on the team should be able to emulate the build environment from their local desktop regardless of their OS.
-  - For projects using VS Code, leveraging [Dev Containers](https://code.visualstudio.com/docs/remote/containers) can really help standardize the local developer experience across the team. Feel free to reuse any one of our technology stack themed dev container from the [container gallery](./devcontainers/). Contributions to the gallery are always welcomed.
+  - For projects using VS Code, leveraging [Dev Containers](https://code.visualstudio.com/docs/remote/containers) can really help standardize the local developer experience across the team. Feel free to reuse any one of our technology stack themed dev container(s) from the [container gallery](./devcontainers/). Contributions to the gallery are always welcomed.
   - Well established software packaging tools like Docker, Maven, npm, etc should be considered when designing your build automation tool chain.
 - [ ] **Document local setup**
   - The setup process for setting up a local build environment should be well documented and easy for developers to follow.


### PR DESCRIPTION
This feature request mentions leveraging dev containers as one option to help unify the local developer experience across an engineering team. I also added a sample dev container used from a recent customer project which automates the local setup of using Terraform and Terratest.