### PR TITLE
Add Terraform Language Server Protocol to Terraform DevContainer

### DIFF
--- a/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG TERRAFORM_VERSION=0.12.24
 ARG TFLINT_VERSION=0.15.3
+ARG TERRAFORM_LSP=0.0.11-beta1
 ARG TERRAFORM_PROVIDER_AZUREDEVOPS_NAME=terraform-provider-azuredevops
 ARG TERRAFORM_PROVIDER_AZUREDEVOPS_REPO=https://github.com/microsoft/terraform-provider-azuredevops.git
 
@@ -24,7 +25,10 @@ RUN apt-get update \
     && curl -sSL -o /tmp/docker-downloads/tflint.zip https://github.com/wata727/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip \
     && unzip /tmp/docker-downloads/tflint.zip \
     && mv tflint /usr/local/bin \
-    && cd ~ \ 
+    && curl -sSL -o /tmp/docker-downloads/lsp.tar.gz https://github.com/juliosueiras/terraform-lsp/releases/download/v${TERRAFORM_LSP}/terraform-lsp_${TERRAFORM_LSP}_linux_amd64.tar.gz \
+    && tar -xvf /tmp/docker-downloads/lsp.tar.gz \
+    && mv terraform-lsp /usr/local/bin \
+    && cd ~ \
     && rm -rf /tmp/docker-downloads \
     # Install the Azure CLI
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \

--- a/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
@@ -21,6 +21,11 @@
 			"enabled": false,
 			"liveIndexing": false
 		},
+		"terraform.languageServer": {
+            "enabled": true,
+            "args": [],
+            "pathToBinary": "/usr/local/bin"
+        },
 		"go.gopath": "/go",
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.useLanguageServer": true,
@@ -55,6 +60,7 @@
 		},
 	},
 	"extensions": [
+		"mauve.terraform",
         "ms-vscode.go",
         "ms-azuretools.vscode-azureterraform",
 		"ms-vscode.azurecli",

--- a/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
+++ b/continuous-integration/devcontainers/terraform/.devcontainer/devcontainer.json
@@ -16,16 +16,16 @@
 	],
 	"postCreateCommand": "mkdir -p /root/.ssh && cp -r /root/.ssh-localhost/* /root/.ssh && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*",
 	"settings": {
-        "files.eol": "\n",
-        "terraform.indexing": {
+		"files.eol": "\n",
+		"terraform.indexing": {
 			"enabled": false,
 			"liveIndexing": false
 		},
 		"terraform.languageServer": {
-            "enabled": true,
-            "args": [],
-            "pathToBinary": "/usr/local/bin"
-        },
+			"enabled": true,
+			"args": [],
+			"pathToBinary": "/usr/local/bin"
+		},
 		"go.gopath": "/go",
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.useLanguageServer": true,
@@ -61,8 +61,8 @@
 	},
 	"extensions": [
 		"mauve.terraform",
-        "ms-vscode.go",
-        "ms-azuretools.vscode-azureterraform",
+		"ms-vscode.go",
+		"ms-azuretools.vscode-azureterraform",
 		"ms-vscode.azurecli",
 		"ms-azuretools.vscode-docker"
 	]


### PR DESCRIPTION
This PR introduces terraform LSP to the Terraform dev container sample. When the dev container builds and launches, LSP will install as well automatically.