### PR TITLE
Updates main branch terminology throughout docs

### DIFF
--- a/TECH-LEADS-CHECKLIST.md
+++ b/TECH-LEADS-CHECKLIST.md
@@ -4,7 +4,7 @@ This checklist helps to ensure that our projects meet our Engineering Fundamenta
 
 ## Source Control
 
-- [ ] The master branch is locked.
+- [ ] The main branch is locked.
 - [ ] Merges are done through PRs.
 - [ ] PRs reference related work items.
 - [ ] Commit history is consistent and commit messages are informative (what, why).
@@ -28,8 +28,8 @@ More details on [Unit Testing](automated-testing/unit-testing/readme.md)
 ## CI/CD
 
 - [ ] Project runs CI with automated build and test on each PR.
-- [ ] Project uses CD to manage deployments to a replica environment before PRs are merged to master.
-- [ ] Master is always shippable.
+- [ ] Project uses CD to manage deployments to a replica environment before PRs are merged.
+- [ ] Main branch is always shippable.
 
 ## Security - TO DO
 

--- a/code-reviews/evidence-and-measures/README.md
+++ b/code-reviews/evidence-and-measures/README.md
@@ -2,9 +2,9 @@
 
 ## Evidence
 
-Many of the code quality assurance items can be automated or enforced by policies in modern version control and work item tracking systems. Verification of the policies on the master branch in [Azure DevOps](https://azure.microsoft.com/en-us/services/devops/) (AzDO) or [GitHub](https://github.com/), for example, may be sufficient evidence that a project team is conducting code reviews.
+Many of the code quality assurance items can be automated or enforced by policies in modern version control and work item tracking systems. Verification of the policies on the main branch in [Azure DevOps](https://azure.microsoft.com/en-us/services/devops/) (AzDO) or [GitHub](https://github.com/), for example, may be sufficient evidence that a project team is conducting code reviews.
 
-* [ ] The master branches in all repositories have branch policies. - [Configure branch policies](branch-policy.md)
+* [ ] The main branches in all repositories have branch policies. - [Configure branch policies](branch-policy.md)
 * [ ] All builds produced out of project repositories include appropriate linters, run unit tests.
 * [ ] Every bug work item should include a link to the pull request that introduced it, once the error has been diagnosed. This helps with learning.
 * [ ] Each bug work item should include a note on how the bug might (or might not have) been caught in a code review.

--- a/code-reviews/faq.md
+++ b/code-reviews/faq.md
@@ -13,7 +13,7 @@ More information can be found in [Pull Requests - Size Guidance](./pull-requests
 
 - Add a rule for PR turnaround time to your work agreement.
 - Setup a slot after the standup to go through pending PRs and assign the ones that are inactive.
-- Dedicate a PR review master who will be responsible to keep things flowing by assigning or notifying people when PR got stale.
+- Dedicate a PR review manager who will be responsible to keep things flowing by assigning or notifying people when PR got stale.
 - Use tools to better indicate stale reviews - [Customize ADO - Task Boards](./process-guidance/customize-ado.md#task-boards).
 
 ## Reviewing a complex PR on GitHub can be hard, is there a more integrated way?

--- a/code-reviews/pull-requests.md
+++ b/code-reviews/pull-requests.md
@@ -31,7 +31,7 @@ We should always aim to have pull requests be as small as possible, without losi
 
 1. They are easier to review; a clear benefit for the reviewers.
 1. They are easier to deploy; this is aligned with the strategy of release fast and release often.
-1. Minimizes possible conflicts and stale PRs, which are difficult to merge and keep in sync with master either because they're very dynamic or contain refactoring.
+1. Minimizes possible conflicts and stale PRs, which are difficult to merge and keep in sync with main branch either because they're very dynamic or contain refactoring.
 
 However, we should avoid having PRs that include code that is without context or loosely coupled.
 

--- a/continuous-integration/CICD.md
+++ b/continuous-integration/CICD.md
@@ -6,7 +6,7 @@ Paired with an automated testing approach, continuous integration also allows us
 
 Continuous Delivery takes the Continuous Integration concept further to also test deployments of the integrated code base on a replica of the environment it will be ultimately deployed on. This enables us to learn early about any unforeseen operational issues that arise from our changes as quickly as possible and also learn about gaps in our test coverage.
 
-The goal of all of this is to ensure that "master is always shippable," meaning that we could, if we needed to, take a build from the master branch of our code base and ship it on production.
+The goal of all of this is to ensure that the main branch is always shippable, meaning that we could, if we needed to, take a build from the main branch of our code base and ship it on production.
 
 If these concepts are unfamiliar to you, take a few minutes and read through [Continuous Integration](https://www.martinfowler.com/articles/continuousIntegration.html) and [Continuous Delivery](https://martinfowler.com/bliki/ContinuousDelivery.html).
 

--- a/continuous-integration/credential-scanning/readme.md
+++ b/continuous-integration/credential-scanning/readme.md
@@ -4,7 +4,7 @@ Credential scanning is the engineering practice of automatically inspecting a pr
 
 Having credentials included in a project's source code not only exposes the project to information security risks resulting from theft and impersonation of the credentials, but also exposes the project to architectural risks such as strongly coupling the project's source code to its infrastructure and deployment specifics. As such, there should be a clear boundary between code and secrets: should be managed outside of the source code, in a system such as [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) or [HashiCorp Vault](https://www.vaultproject.io) and credential scanning should be employed to ensure that this boundary is never violated.
 
-Ideally, credential scanning should be run as part of a developer's workflow (e.g. via a [git pre-commit hook](https://githooks.com)), however, to protect against developer error, credential scanning must also be enforced as part of the continuous integration process to ensure that no credentials ever get merged to a project's master branch.
+Ideally, credential scanning should be run as part of a developer's workflow (e.g. via a [git pre-commit hook](https://githooks.com)), however, to protect against developer error, credential scanning must also be enforced as part of the continuous integration process to ensure that no credentials ever get merged to a project's main branch.
 
 To implement credential scanning for a project, consider building on-top of one of the following recipes:
 

--- a/continuous-integration/readme.md
+++ b/continuous-integration/readme.md
@@ -62,7 +62,7 @@ An automated build should encompass the following principles:
 - [ ] **Build Script Target**
   - A single command should have the capability of building the system. This is also true for builds running on a CI server or on a developers local machine.
 - [ ] **No IDE Dependencies**
-  - It's essential to have a master build that's runnable through standalone scripts and not dependent on a particular IDE. Build pipeline targets can be triggered locally on their desktops through their IDE of choice. The build process should maintain enough flexibility to run within a CI server as well. As an example, dockerizing your build process offers this level of flexibility as VSCode and IntelliJ supports [docker plugin](https://code.visualstudio.com/docs/containers/overview) extensions.
+  - It's essential to have a build that's runnable through standalone scripts and not dependent on a particular IDE. Build pipeline targets can be triggered locally on their desktops through their IDE of choice. The build process should maintain enough flexibility to run within a CI server as well. As an example, dockerizing your build process offers this level of flexibility as VSCode and IntelliJ supports [docker plugin](https://code.visualstudio.com/docs/containers/overview) extensions.
 
 ## Build Environment Dependencies
 
@@ -157,9 +157,9 @@ An effective way to identify bugs in your build at a rapid pace is to invest ear
   - Avoid commenting out tests in the mainline branch. By commenting out tests, we get an incorrect indication of the status of the build.
 
 - [ ] **Branch policy enforcement**
-  - Protected [branch policies](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) should be setup on master to ensure that CI stage(s) have passed prior to starting a code review. Code review approvers will only start reviewing a pull request once the CI pipeline run passes for the latest pushed git commit.
+  - Protected [branch policies](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) should be setup on the main branch to ensure that CI stage(s) have passed prior to starting a code review. Code review approvers will only start reviewing a pull request once the CI pipeline run passes for the latest pushed git commit.
   - Broken builds should block pull request reviews.
-  - Prevent commits directly into master.
+  - Prevent commits directly into main branch.
 
 - [ ] **Branch strategy**
   - Release branches should auto trigger the deployment of a build artifact to it's target cloud environment. One branch strategy worth considering is  [trunk-based development](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#manage-releases) and [Release Flow's Branching Structure](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow).
@@ -198,7 +198,7 @@ Our devops workflow should enable developers to get, install and run the latest 
 - [ ] **Developers can access latest executable**
   - Latest system executable is available for all developers on the team. There should be a well-known place where developers can reference the release artifact.
 
-- [ ] **Release artifact is published for each pull request or merges into master**
+- [ ] **Release artifact is published for each pull request or merges into main branch**
 
 ## Integration Observability
 

--- a/design-reviews/recipes/async-design-reviews.md
+++ b/design-reviews/recipes/async-design-reviews.md
@@ -47,7 +47,7 @@ Design documentation must live in a source control repository that supports pull
 3. The designer submits pull request and requests specific team members to review.
 4. Reviewers provide feedback to Designer who incorporates the feedback.
 5. (OPTIONAL) Design review meeting might be held to give deeper explanation of design to reviewers.
-6. Design is approved/accepted and merged to master.
+6. Design is approved/accepted and merged to main branch.
 
 ![Async Design Review Workflow](assets/async-design-reviews-sequence.png)
 

--- a/developer-experience/readme.md
+++ b/developer-experience/readme.md
@@ -146,7 +146,7 @@ VS.
 
 #### Atomic Pull Requests
 
-When the solution is encapsulated within a single repository, it also allows pull requests to represent a change across multiple layers. This is especially helpful when a change requires changes to a shared contract between multiple components. For example, a story requires that an api endpoint is changed. With this strategy the api and web client could be updated with the same pull request. This avoids master being broken temporarily while waiting on dependent pull requests to merge.
+When the solution is encapsulated within a single repository, it also allows pull requests to represent a change across multiple layers. This is especially helpful when a change requires changes to a shared contract between multiple components. For example, a story requires that an api endpoint is changed. With this strategy the api and web client could be updated with the same pull request. This avoids the main branch being broken temporarily while waiting on dependent pull requests to merge.
 
 [`TODO: Add link to other documented benefits of consolidated repos within source control section`]
 

--- a/source-control/contributing/readme.md
+++ b/source-control/contributing/readme.md
@@ -87,45 +87,45 @@ Agree if you want a linear or non-linear commit history. There are pros and cons
 
 ### Approach for non-linear commit history
 
-Merging `topic` into `master`
+Merging `topic` into `main`
 
 ```md
   A---B---C topic
  /         \
-D---E---F---G---H master
+D---E---F---G---H main
 
 git fetch origin
-git checkout master
+git checkout main
 git merge topic
 ```
 
 ### Two approaches to achieve a linear commit history
 
-#### Rebase topic branch before merging into master
+#### Rebase topic branch before merging into main
 
-Before merging `topic` into `master`, we rebase `topic` with the   :
+Before merging `topic` into `main`, we rebase `topic` with the   :
 
 ```bash
           A---B---C topic
          /         \
-D---E---F-----------G---H master
+D---E---F-----------G---H main
 
 git fetch origin
-git rebase master topic
-git checkout master
+git rebase main topic
+git checkout main
 git merge topic
 ```
 
-#### Rebase topic branch before squash merge into master
+#### Rebase topic branch before squash merge into main
 
-[Squash merging](https://docs.microsoft.com/en-us/azure/devops/repos/git/merging-with-squash?view=azure-devops) is a merge option that allows you to condense the Git history of topic branches when you complete a pull request. Instead of adding each commit on `topic` to the history of `master`, a squash merge takes all the file changes and adds them to a single new commit on `master`.
+[Squash merging](https://docs.microsoft.com/en-us/azure/devops/repos/git/merging-with-squash?view=azure-devops) is a merge option that allows you to condense the Git history of topic branches when you complete a pull request. Instead of adding each commit on `topic` to the history of `main`, a squash merge takes all the file changes and adds them to a single new commit on `main`.
 
 ```bash
           A---B---C topic
          /
-D---E---F-----------G---H master
+D---E---F-----------G---H main
 
-Create a PR topic --> master in Azure DevOps and approve using the squash merge option
+Create a PR topic --> main in Azure DevOps and approve using the squash merge option
 ```
 
 ## Naming branches

--- a/source-control/readme.md
+++ b/source-control/readme.md
@@ -13,7 +13,7 @@ There are many different options when working with Source Control. In [CSE](../C
 ## Goal
 
 * Following industry best practice to work in geo-distributed teams which encourage contributions from all across [CSE](../CSE.md) as well as the broader OSS community
-* Improve code quality by enforcing reviews before merging into master branches
+* Improve code quality by enforcing reviews before merging into main branches
 * Improve traceability of features and fixes through a clean commit history
 
 ## General Guidance

--- a/team-agreements/working-agreements/readme.md
+++ b/team-agreements/working-agreements/readme.md
@@ -56,7 +56,7 @@ The following are examples of sections and points that can be part of a working 
 ## Code management
 
 - We follow the git flow branch naming convention for branches and identify the task number eg. `feature/123-add-working-agreement`
-- We merge all code into Develop and Master through PRs
+- We merge all code into main branches through PRs
 - All PRs are reviewed by one person from [Customer/Partner Name] and one from Microsoft (for knowledge transfer and to ensure code and security standards are met)
 - We always review existing PRs before starting work on a new task
 - We look through open PRs at the end of stand-up to make sure all PRs have reviewers.


### PR DESCRIPTION
Changes wording to "main branch" instead of "master" or "master branch" in most places throughout the code base.

There are a handful of locations where this was not changed yet:
- In code fences where examples were provided
- In sections where the docs provide an example of working with git

Fixes #318