### PR TITLE
Replace scrum master with process lead

### DIFF
--- a/SPRINT-STRUCTURE.md
+++ b/SPRINT-STRUCTURE.md
@@ -41,7 +41,7 @@ The purpose of this document is to:
 - [ ] [Set up Source Control](source-control/readme.md)
   - Agree on [best practices for commits](source-control/contributing/readme.md#commit-best-practices)
 - [ ] [Set up basic Continuous Integration with linters and automated tests](continuous-integration/readme.md)
-- [ ] [Set up meetings for Daily Standups and decide on a scrum master](stand-ups/readme.md)
+- [ ] [Set up meetings for Daily Standups and decide on a Process Lead](stand-ups/readme.md)
   - Discuss purpose, goals, participants and facilitation guidance
   - Discuss timing, and how to run an efficient stand-up
 - [ ] [If the project has sub-teams, set up a Scrum of Scrums](scrum-of-scrums/readme.md)

--- a/TECH-LEADS-CHECKLIST.md
+++ b/TECH-LEADS-CHECKLIST.md
@@ -50,7 +50,7 @@ More details on [Unit Testing](automated-testing/unit-testing/readme.md)
 
 ## Agile/Scrum
 
-- [ ] Scrum Master (fixed/rotating) to run standup daily.
+- [ ] Process Lead (fixed/rotating) to run standup daily.
 - [ ] Agile process clearly defined within team.
 - [ ] Tech Lead (+ PO/Others) have responsibility for backlog management and grooming.
 - [ ] Working agreement between members of team and customer.

--- a/retrospectives/readme.md
+++ b/retrospectives/readme.md
@@ -61,7 +61,7 @@ Iteration reviews should follow the ceremony of the retrospective script, but us
 
 An iteration retrospective will usually take **1-2 hours**.
 
-Usually, the scrum master or engineering manager will lead the first one or two iteration retrospectives. After that, it's good for the team to take turns.
+Usually, the process lead or engineering manager will lead the first one or two iteration retrospectives. After that, it's good for the team to take turns.
 
 1. Set the stage.
     1. Run a quick Working Agreement activity (4.4) to give participants a chance to add any items to the standard working agreement.
@@ -82,7 +82,7 @@ This variation assumes that the team is running an iteration per day, which is c
 
 A single-day iteration retrospective will usually take **15-30 minutes**.
 
-The scrum master or engineering manager will lead these short retrospectives.
+The process lead or engineering manager will lead these short retrospectives.
 
 1. Set the stage.
     1. Remind everyone of the team's working agreement for daily retrospectives.

--- a/scrum-of-scrums/readme.md
+++ b/scrum-of-scrums/readme.md
@@ -19,7 +19,7 @@ This list of impediments is usually managed in a separate [backlog](../backlog-m
 
 ## Participation
 
-The common guideline is to have on average one person per sub team to participate in the scrum of scrums. Ideally, the scrum master of each sub team would represent them in this ceremony. In some instances, the representative for the day is selected at the end of each sub team daily [stand-up](../stand-ups/readme.md) and could change every day. In practice, having a fixed representative tends to be more efficient in the long term.
+The common guideline is to have on average one person per sub team to participate in the scrum of scrums. Ideally, the process lead of each sub team would represent them in this ceremony. In some instances, the representative for the day is selected at the end of each sub team daily [stand-up](../stand-ups/readme.md) and could change every day. In practice, having a fixed representative tends to be more efficient in the long term.
 
 ## Impact
 

--- a/sprint-planning/readme.md
+++ b/sprint-planning/readme.md
@@ -22,7 +22,7 @@ General guidance:
 
 Specific roles:
 
-- [Scrum Master](https://www.agilealliance.org/glossary/scrum-master):
+- [Process Lead](https://www.agilealliance.org/glossary/scrum-master):
   - Facilitate the conversation.
   - Ensure everyone is heard.
   - Remind scrums principles and sprint planning goals if necessary.

--- a/sprint-planning/readme.md
+++ b/sprint-planning/readme.md
@@ -22,10 +22,10 @@ General guidance:
 
 Specific roles:
 
-- [Process Lead](https://www.agilealliance.org/glossary/scrum-master):
+- [Process Lead]:
   - Facilitate the conversation.
   - Ensure everyone is heard.
-  - Remind scrums principles and sprint planning goals if necessary.
+  - Remind scrums/agile/other principles and sprint planning goals if necessary, updating the working agreement where needed to ensure a mapping between principals and what is working/not working for the team.
 - [Product owner](https://www.agilealliance.org/glossary/product-owner/):
   - Prior to the sprint planning: performs some [backlog grooming](../backlog-management/grooming/readme.md) to ensure that each story that they want to propose for the new sprint (*) :
   

--- a/stand-ups/readme.md
+++ b/stand-ups/readme.md
@@ -21,7 +21,7 @@ The term parking lot refers to a bucket of comments, concerns, or questions that
 
 The entire team should attend the stand-up. Anyone that worked on a task towards the sprint work should answer the three questions. It would be up to the team to decide if they would like updates from members that are not directly working against sprint task work (i.e. Product Owners and Program Managers).
 
-- Scrum Master (Required)
+- Process Lead (Required)
 - Product Owner (Optional)
 - Program Manager (Required)
 - Dev Manager (Required)
@@ -61,7 +61,7 @@ How many tasks are being generated after the stand-up that didn't exist before? 
 
 ## Facilitation Guidance
 
-The scrum master should facilitate the stand-up meeting.
+The process lead should facilitate the stand-up meeting.
 
 ### Speak to Tasks
 
@@ -76,7 +76,7 @@ If a contributor is not working on an existing sprint task they need to either c
 
 ### Parking Lot Discussion Items
 
-As contributors are answering the three questions, if another contributor has a question or issue to share, they should reserve until after all contributors have answered finished. Once each member has answered all three questions, the scrum master should open up the floor to anyone who may have an open question or unresolved issue to share. This portion of the ceremony is often referred to as the "Parking Lot".
+As contributors are answering the three questions, if another contributor has a question or issue to share, they should reserve until after all contributors have answered finished. Once each member has answered all three questions, the process lead should open up the floor to anyone who may have an open question or unresolved issue to share. This portion of the ceremony is often referred to as the "Parking Lot".
 
 **Parking lot discussions are optional for participants**. Ensure discussion leaders call out necessary parties for their discussion points upfront, allowing those not needed to leave the meeting.
 
@@ -107,4 +107,4 @@ For teams distributed across time zones, consider scheduling standup between 9 a
 
 ### Contributors Unable to Attend (async updates)
 
-If a contributor knows that they will have to miss the stand-up, ask them to provide their answers to the 3 questions in written form before the stand-up. They could provide these over a shared Teams channel or email to the team. The scrum master can then read the answers during the stand-up. Reading the update aloud during the stand-up will ensure the answers are communicated to the team.
+If a contributor knows that they will have to miss the stand-up, ask them to provide their answers to the 3 questions in written form before the stand-up. They could provide these over a shared Teams channel or email to the team. The process lead can then read the answers during the stand-up. Reading the update aloud during the stand-up will ensure the answers are communicated to the team.

--- a/team-agreements/definition-of-ready/readme.md
+++ b/team-agreements/definition-of-ready/readme.md
@@ -23,7 +23,7 @@ It can be understood as a checklist that helps the Product Owner to ensure that 
 
 ## Who writes it
 
-The ready checklist can be written by a Product Owner in agreement with the development team and the scrum master.
+The ready checklist can be written by a Product Owner in agreement with the development team and the Process Lead.
 
 ## When should a Definition of Ready be updated
 

--- a/team-agreements/working-agreements/readme.md
+++ b/team-agreements/working-agreements/readme.md
@@ -36,9 +36,9 @@ The following are examples of sections and points that can be part of a working 
 
 | Activity | When | Duration | Who | Accountable | Goal |
 |-|-|-|-|-|-|
-| [Project Standup](./sprint-planning/../../../stand-ups/readme.md) | Tue-Fri 9AM | 15 min | Everyone | Scrum Master | What has been accomplished, next steps, blockers |
+| [Project Standup](./sprint-planning/../../../stand-ups/readme.md) | Tue-Fri 9AM | 15 min | Everyone | Process Lead | What has been accomplished, next steps, blockers |
 | Sprint Demo | Monday 9AM | 1 hour | Everyone | Tech Lead | Present work done and sign off on user story completion |
-| [Sprint Retro](./../../retrospectives/readme.md) | Monday 10AM | 1 hour | Everyone | Scrum Master | Dev Teams shares learnings and what can be improved |
+| [Sprint Retro](./../../retrospectives/readme.md) | Monday 10AM | 1 hour | Everyone | Process Lead | Dev Teams shares learnings and what can be improved |
 | [Sprint Planning](./../../sprint-planning/readme.md) | Monday 11AM | 1 hour | Everyone | PO | Size and plan user stories for the sprint |
 | Task Creation | After Sprint Planning | - | Dev Team | Tech Lead | Create tasks to clarify and determine velocity |
 | [Backlog grooming](../../backlog-management/grooming/readme.md) | Wednesday 2PM | 1 hour | Tech lead, PO | PO | Prepare for next sprint and ensure that stories are ready for next sprint. |

--- a/team-agreements/working-agreements/readme.md
+++ b/team-agreements/working-agreements/readme.md
@@ -43,6 +43,22 @@ The following are examples of sections and points that can be part of a working 
 | Task Creation | After Sprint Planning | - | Dev Team | Tech Lead | Create tasks to clarify and determine velocity |
 | [Backlog grooming](../../backlog-management/grooming/readme.md) | Wednesday 2PM | 1 hour | Tech lead, PO | PO | Prepare for next sprint and ensure that stories are ready for next sprint. |
 
+## Process Lead
+
+The process lead is responsible for leading any scrum or agile practices to enable the project to move forward. Recommended responsibilities are below, as well as in the CWC Wiki.
+
+- Facilitate standup meetings and hold team accountable for attendance and participation.
+- Keep the meeting moving as described in the [Project Standup](./sprint-planning/../../../stand-ups/readme.md) page.
+- Make sure all action items are documented and ensure each has an owner and a due date and tracks the open issues.
+- Notes as needed after planning / standups.
+- Make sure that items are moved to the parking lot and ensure follow-up afterwards.
+- Maintain a location showing team’s work and status and removing impediments that are blocking the team.
+- Hold the team accountable for results in a supportive fashion.
+- Make sure that project and program documentation are up-to-date.
+- Guarantee the tracking/following up on action items from retrospectives (iteration and release planning) and from daily standup meetings.
+- Facilitate the sprint retrospective.
+- Coach Product Owner and the team in the process, as needed.
+
 ## Backlog management
 
 - We work together on a [Definition of Ready](../definition-of-ready/readme.md) and all user stories assigned to a sprint need to follow this


### PR DESCRIPTION
# Replace scrum master with process lead

## Link to the design document that prompted this PR

- Relevant Teams threads can be found in CSE General as AMA question responses as well as dedicated post from Michael Brown.

## What are you trying to address

- "Scrum Master" should not be the term we use for multiple reasons. Firstly, the connotation of the usage of the word "master." Secondly, this Process Lead should lead the team through processes outside of scrum, including agile and other processes the team agrees to use.

## Description of new changes

- This is just a documentation change
- I found all uses of "scrum master" and replaced with "process lead"
- In places where needed, I explained briefly what a process lead is.

## How did you test it

- N/A

## Any relevant logs or outputs

- N/A

### Other information or known dependencies

- Fixes #328 