### PR TITLE
Add documentation for Trade Studies

### DIFF
--- a/design-reviews/readme.md
+++ b/design-reviews/readme.md
@@ -110,3 +110,4 @@ Design reviews come in all shapes and sizes. There are also different items to c
 
 - Document and update the architecture design in the project design documentation
 - Track and document design decisions in a [decision log](./decision-log/readme.md)
+- Document decision process in [trade studies](./trade-studies/readme.md) when multiple solutions exist for the given problem

--- a/design-reviews/trade-studies/readme.md
+++ b/design-reviews/trade-studies/readme.md
@@ -1,11 +1,11 @@
 # Trade Studies
 
 Trade studies are a tool for selecting the best option out of several possible options for a given problem (for example: compute, storage).
-They evaluate potential choices against a set of objective criteria/customer requirements to clearly lay out the benefits and limitations
+They evaluate potential choices against a set of objective criteria/requirements to clearly lay out the benefits and limitations
 of each solution.
 
-[Trade studies](https://en.wikipedia.org/wiki/Trade_study) are a concept from systems engineering that we adapted for CSE projects. Trade
-studies have proved to be a critical tool to drive alignment with the customers, earn credibility while doing so and ensure our decisions
+[Trade studies](https://en.wikipedia.org/wiki/Trade_study) are a concept from systems engineering that we adapted for software projects. Trade
+studies have proved to be a critical tool to drive alignment with the stakeholders, earn credibility while doing so and ensure our decisions
 were backed by data and not bias.  
 
 ## When to use the tool
@@ -21,24 +21,20 @@ should be made in the [Decision Log](../decision-log/readme.md) documenting the 
 
 ## Why Trade Studies
 
-The biggest advantage of using trade studies is formalizing the decision-making process in a clear and objective manner. This gives a clear
-flow for presenting the information to decision makers. We recommend the following approach for sharing information:
+Trade studies are a way of formalizing the design process and leaving a documentation record for why the decision was made. This gives a few advantages:
 
-|Sharing Approach|Customer Cloud Maturity|Content Presentations|Tools Used fo Writing/Sharing|
-|-|-|-|-|
-|Lightweight|Beginner|Executive summary, Diagrams/visuals, comparison tables | Word doc with referenced Visio diagram and Excel tables, Wiki software with built-in visuals|
-|Full Experience|Intermediate to advanced|All of the above, 30-50% of the trade study text|Same as above|
-
-Additionally, filling out the trade study template provides structure to the design phase and leaves a documentation record of assumptions
-and data that went into each decision.
+1. The trade study template guides a user through the design process. This provides structure to the design stage.
+1. Having a uniform design process aids splitting work amongst team members. We have had success with engineers pairing to define requirements, evaluation criteria, and brainstorming possible solutions. Then they can each split to review solutions in parallel, before rejoining to make the final decision.
+1. The completed trade study document helps drive alignment across the team and decision makers. For presenting results of the study, the document itself can be used to highlight the main points. Alternatively, we have extracted requirements, diagrams for each solution and the results table into a slide deck to give high level overviews of the results.
+1. The completed trade study gets checked into the code repository, providing documentation of the decision process. This leaves a history of the requirements at the time that lead to each decision. Also, the results table gives a quick reference for how the decision would be impacted if requirements change as the project proceeds.
 
 ## Flow of a Trade Study
 
 Trade studies can vary widely in scope; however, they follow the common pattern below:
 
-1. Solidify the requirements – Work with the customer to agree on the requirements for the functionality that you are trying to build.
+1. Solidify the requirements – Work with the stakeholders to agree on the requirements for the functionality that you are trying to build.
 1. Create evaluation criteria – This is a set of qualitative and quantitative assessment points that represent the requirements. Taken together, they become an easy to measure stand-in for the potentially abstract requirements.
-1. Brainstorm solutions – Gather a list of possible solutions to the problem. Then, use your best judgement to pick the 2-4 solutions that seem most promising. For assistance narrowing solutions, reach out to Tech Domains, Product Groups and other XDC teams that have faced similar problems.
+1. Brainstorm solutions – Gather a list of possible solutions to the problem. Then, use your best judgement to pick the 2-4 solutions that seem most promising. For assistance narrowing solutions, remember to reach out to subject matter experts and other teams who may have gone through a similar decision.
 1. Evaluate shortlisted solutions – Dive deep into each solution and measure it against the evaluation criteria. In this stage, timebox your research to avoid overly investing in any given area.
 1. Compare results and choose solution - Align the decision with the team. If you are unable to decide, then a clear list of action items and owners to drive the final decision must be produced.
 

--- a/design-reviews/trade-studies/readme.md
+++ b/design-reviews/trade-studies/readme.md
@@ -4,7 +4,7 @@ Trade studies are a tool for selecting the best option out of several possible o
 They evaluate potential choices against a set of objective criteria/customer requirements to clearly lay out the benefits and limitations
 of each solution.
 
-[Trade studies](https://en.wikipedia.org/wiki/Trade_study) are a concept from systems engineering that we adapted for CSE projects. Trade 
+[Trade studies](https://en.wikipedia.org/wiki/Trade_study) are a concept from systems engineering that we adapted for CSE projects. Trade
 studies have proved to be a critical tool to drive alignment with the customers, earn credibility while doing so and ensure our decisions
 were backed by data and not bias.  
 
@@ -14,13 +14,13 @@ The ideal stage to do trade studies is after the game plan completion and before
 level architecture design. Further they can be used whenever the project requirements are changing, and we need to reevaluate solutions.
 
 Trade studies should be avoided if there is a clear solution choice. Because they require each solution to be fully thought out, they
-have the potential to take a lot of time to complete. When there is a clear design, the trade study should be omitted and an entry 
+have the potential to take a lot of time to complete. When there is a clear design, the trade study should be omitted and an entry
 should be made in the [Decision Log](../decision-log/readme.md) documenting the decision.
 
 ## Why Trade Studies
 
 The biggest advantage of using trade studies is formalizing the decision-making process in a clear and objective manner. This gives a clear
-flow for presenting the information to decision makers. We recommend the following approach for sharing information: 
+flow for presenting the information to decision makers. We recommend the following approach for sharing information:
 
 |Sharing Approach|Customer Cloud Maturity|Content Presentations|Tools Used fo Writing/Sharing|
 |-|-|-|-|
@@ -28,20 +28,20 @@ flow for presenting the information to decision makers. We recommend the followi
 |Full Experience|Intermediate to advanced|All of the above, 30-50% of the trade study text|Same as above|
 
 Additionally, filling out the trade study template provides structure to the design phase and leaves a documentation record of assumptions
-and data that went into each decision. 
+and data that went into each decision.
 
 ## Flow of a Trade Study
 
 Trade studies can vary widely in scope; however, they follow the common pattern below:
 
-1. Solidify the requirements – Work with the customer to agree on the requirements for the functionality that you are trying to build. 
-1. Create evaluation criteria – This is a set of qualitative and quantitative assessment points that represent the requirements. Taken together, they become an easy to measure stand-in for the potentially abstract requirements. 
-1. Brainstorm solutions – Gather a list of possible solutions to the problem. Then, use your best judgement to pick the 2-4 solutions that seem most promising. For assistance narrowing solutions, reach out to Tech Domains, Product Groups and other XDC teams that have faced similar problems.  
-1. Evaluate shortlisted solutions – Dive deep into each solution and measure it against the evaluation criteria. In this stage, timebox your research to avoid overly investing in any given area. 
+1. Solidify the requirements – Work with the customer to agree on the requirements for the functionality that you are trying to build.
+1. Create evaluation criteria – This is a set of qualitative and quantitative assessment points that represent the requirements. Taken together, they become an easy to measure stand-in for the potentially abstract requirements.
+1. Brainstorm solutions – Gather a list of possible solutions to the problem. Then, use your best judgement to pick the 2-4 solutions that seem most promising. For assistance narrowing solutions, reach out to Tech Domains, Product Groups and other XDC teams that have faced similar problems.
+1. Evaluate shortlisted solutions – Dive deep into each solution and measure it against the evaluation criteria. In this stage, timebox your research to avoid overly investing in any given area.
 1. Compare results and choose solution - Align the decision with the team. If you are unable to decide, then a clear list of action items and owners to drive the final decision must be produced.
 
-## Template 
+## Template
 
-See [template.md](./template.md) for an example of how to structure the above information. This template was created to guide a user 
-through conducting a trade study. Once the decision has been made we recommend adding an entry to the 
+See [template.md](./template.md) for an example of how to structure the above information. This template was created to guide a user
+through conducting a trade study. Once the decision has been made we recommend adding an entry to the
 [Decision Log](../decision-log/readme.md) that has references back to the full text of the trade study.

--- a/design-reviews/trade-studies/readme.md
+++ b/design-reviews/trade-studies/readme.md
@@ -10,8 +10,10 @@ were backed by data and not bias.
 
 ## When to use the tool
 
-The ideal stage to do trade studies is after the game plan completion and before coding begins; they go hand in hand with defining high
-level architecture design. Further they can be used whenever the project requirements are changing, and we need to reevaluate solutions.
+Trade studies go hand in hand with high level architecture design. This usually occurs as project requirements are solidifying, before
+coding begins. Trade studies continue to be useful throughout the project at any time where there are multiple options that need
+to be selected from. New decision point could occur from changing requirements, getting results of a research spike, or identifying
+challenges that were not originally seen.
 
 Trade studies should be avoided if there is a clear solution choice. Because they require each solution to be fully thought out, they
 have the potential to take a lot of time to complete. When there is a clear design, the trade study should be omitted and an entry

--- a/design-reviews/trade-studies/readme.md
+++ b/design-reviews/trade-studies/readme.md
@@ -1,0 +1,47 @@
+# Trade Studies
+
+Trade studies are a tool for selecting the best option out of several possible options for a given problem (for example: compute, storage).
+They evaluate potential choices against a set of objective criteria/customer requirements to clearly lay out the benefits and limitations
+of each solution.
+
+[Trade studies](https://en.wikipedia.org/wiki/Trade_study) are a concept from systems engineering that we adapted for CSE projects. Trade 
+studies have proved to be a critical tool to drive alignment with the customers, earn credibility while doing so and ensure our decisions
+were backed by data and not bias.  
+
+## When to use the tool
+
+The ideal stage to do trade studies is after the game plan completion and before coding begins; they go hand in hand with defining high
+level architecture design. Further they can be used whenever the project requirements are changing, and we need to reevaluate solutions.
+
+Trade studies should be avoided if there is a clear solution choice. Because they require each solution to be fully thought out, they
+have the potential to take a lot of time to complete. When there is a clear design, the trade study should be omitted and an entry 
+should be made in the [Decision Log](../decision-log/readme.md) documenting the decision.
+
+## Why Trade Studies
+
+The biggest advantage of using trade studies is formalizing the decision-making process in a clear and objective manner. This gives a clear
+flow for presenting the information to decision makers. We recommend the following approach for sharing information: 
+
+|Sharing Approach|Customer Cloud Maturity|Content Presentations|Tools Used fo Writing/Sharing|
+|-|-|-|-|
+|Lightweight|Beginner|Executive summary, Diagrams/visuals, comparison tables | Word doc with referenced Visio diagram and Excel tables, Wiki software with built-in visuals|
+|Full Experience|Intermediate to advanced|All of the above, 30-50% of the trade study text|Same as above|
+
+Additionally, filling out the trade study template provides structure to the design phase and leaves a documentation record of assumptions
+and data that went into each decision. 
+
+## Flow of a Trade Study
+
+Trade studies can vary widely in scope; however, they follow the common pattern below:
+
+1. Solidify the requirements – Work with the customer to agree on the requirements for the functionality that you are trying to build. 
+1. Create evaluation criteria – This is a set of qualitative and quantitative assessment points that represent the requirements. Taken together, they become an easy to measure stand-in for the potentially abstract requirements. 
+1. Brainstorm solutions – Gather a list of possible solutions to the problem. Then, use your best judgement to pick the 2-4 solutions that seem most promising. For assistance narrowing solutions, reach out to Tech Domains, Product Groups and other XDC teams that have faced similar problems.  
+1. Evaluate shortlisted solutions – Dive deep into each solution and measure it against the evaluation criteria. In this stage, timebox your research to avoid overly investing in any given area. 
+1. Compare results and choose solution - Align the decision with the team. If you are unable to decide, then a clear list of action items and owners to drive the final decision must be produced.
+
+## Template 
+
+See [template.md](./template.md) for an example of how to structure the above information. This template was created to guide a user 
+through conducting a trade study. Once the decision has been made we recommend adding an entry to the 
+[Decision Log](../decision-log/readme.md) that has references back to the full text of the trade study.

--- a/design-reviews/trade-studies/template.md
+++ b/design-reviews/trade-studies/template.md
@@ -2,68 +2,68 @@
 
 This generic template can be used for any situation where we have a set of requirements that can be satisfied
 by multiple solutions. They can range in scope from choice of which open source package to use through full
-architecture designs.  
+architecture designs.
 
-# Trade Study: {study name goes here} 
+## Trade Study: {study name goes here}
 
-Conducted by: {Names and at least one email address for follow up questions} 
+Conducted by: {Names and at least one email address for follow up questions}
 
-Backlog Work Item: {Link to the work item to provide more context} 
+Backlog Work Item: {Link to the work item to provide more context}
 
-Date:  
+Date:
 
-Decision: {Solution chosen to proceed with} 
+Decision: {Solution chosen to proceed with}
 
-Decision Makers:  
+Decision Makers:
 
-Date:  
+Date:
 
-# Overview 
+## Overview
 
-Description of the problem we are solving. This should include: 
+Description of the problem we are solving. This should include:
 
-1. Assumptions about the rest of the system 
-1. Constraints that apply to the system, both business and technical 
-1. Requirements for the functionality that needs to be implemented, including possible inputs and outputs 
-1. [Optional] A diagram showing the different pieces 
+1. Assumptions about the rest of the system
+1. Constraints that apply to the system, both business and technical
+1. Requirements for the functionality that needs to be implemented, including possible inputs and outputs
+1. [Optional] A diagram showing the different pieces
 
-## Evaluation Criteria 
+### Evaluation Criteria
 
 The former should be condensed down to a set of "evaluation criteria" that we can rate any potential solutions
-against. Examples of evaluation criteria: 
+against. Examples of evaluation criteria:
 
-* Runs on Windows and Linux - Binary response 
-* Compute Usage - Could be categories that effectively rank different options: High, Medium, Low 
-* Cost of the solution – An estimated numeric field 
+* Runs on Windows and Linux - Binary response
+* Compute Usage - Could be categories that effectively rank different options: High, Medium, Low
+* Cost of the solution – An estimated numeric field
 
-The results section contains a table evaluating each solution against the evaluation criteria. 
+The results section contains a table evaluating each solution against the evaluation criteria.
 
-# Solutions 
+## Solutions
 
-The following sections enumerate possible solutions to this problem. There should be at least two options 
-compared, otherwise you didn't need a trade study. 
+The following sections enumerate possible solutions to this problem. There should be at least two options
+compared, otherwise you didn't need a trade study.
 
-## {Solution 1} - Short easily recognizable name 
+### {Solution 1} - Short easily recognizable name
 
-Each solution section should contain the following: 
+Each solution section should contain the following:
 
-1. Description of the solution 
-1. (optional) A diagram to quickly reference the solution 
-1. Possible variations - things that are small variations on the main solution can be grouped together 
-1. Evaluation of the idea based on the evaluation criteria above 
+1. Description of the solution
+1. (optional) A diagram to quickly reference the solution
+1. Possible variations - things that are small variations on the main solution can be grouped together
+1. Evaluation of the idea based on the evaluation criteria above
 
 The depth, detail, and contents of these sections will vary based on the complexity of the functionality
 being developed.
- 
-## {Solution 2} 
 
-... 
+### {Solution 2}
 
-## {Solution N} 
+...
 
-# Results 
+### {Solution N}
 
-This section should contain a table that has each solution rated against each of the evaluation criteria: 
+## Results
+
+This section should contain a table that has each solution rated against each of the evaluation criteria:
 
 |Solution|Evaluation Criteria 1|Evaluation Criteria 2|...|Evaluation Criteria N|
 |--------|---------------------|---------------------|---|---------------------|
@@ -73,11 +73,11 @@ This section should contain a table that has each solution rated against each of
 |Solution M|||||
 
 Note: The formatting of the table can change. In the past, we have had success with qualitative descriptions
-in the table entries and color coding the cells to represent good, fair, bad. 
+in the table entries and color coding the cells to represent good, fair, bad.
 
-# Decision 
+## Decision
 
-The chosen solution, or a list of questions that need to be answered before the decision can be made.  
+The chosen solution, or a list of questions that need to be answered before the decision can be made.
 
-In the latter case, each question needs an action item and an assigned person for answering the question. 
-Once those questions are answered, the document must be updated to reflect the answers and the final decision 
+In the latter case, each question needs an action item and an assigned person for answering the question.
+Once those questions are answered, the document must be updated to reflect the answers and the final decision

--- a/design-reviews/trade-studies/template.md
+++ b/design-reviews/trade-studies/template.md
@@ -1,0 +1,81 @@
+This generic template can be used for any situation where we have a set of requirements that can be satisfied 
+by multiple solutions. They can range in scope from choice of which open source package to use through full 
+architecture designs.  
+
+# Trade Study: {study name goes here} 
+
+Conducted by: {Names and at least one email address for follow up questions} 
+
+Backlog Work Item: {Link to the work item to provide more context} 
+
+Date:  
+
+Decision: {Solution chosen to proceed with} 
+
+Decision Makers:  
+
+Date:  
+
+# Overview 
+
+Description of the problem we are solving. This should include: 
+
+1. Assumptions about the rest of the system 
+1. Constraints that apply to the system, both business and technical 
+1. Requirements for the functionality that needs to be implemented, including possible inputs and outputs 
+1. [Optional] A diagram showing the different pieces 
+
+## Evaluation Criteria 
+
+The former should be condensed down to a set of "evaluation criteria" that we can rate any potential solutions
+against. Examples of evaluation criteria: 
+
+* Runs on Windows and Linux - Binary response 
+* Compute Usage - Could be categories that effectively rank different options: High, Medium, Low 
+* Cost of the solution – An estimated numeric field 
+
+The results section contains a table evaluating each solution against the evaluation criteria. 
+
+# Solutions 
+
+The following sections enumerate possible solutions to this problem. There should be at least two options 
+compared, otherwise you didn't need a trade study. 
+
+## {Solution 1} - Short easily recognizable name 
+
+Each solution section should contain the following: 
+
+1. Description of the solution 
+1. (optional) A diagram to quickly reference the solution 
+1. Possible variations - things that are small variations on the main solution can be grouped together 
+1. Evaluation of the idea based on the evaluation criteria above 
+
+The depth, detail, and contents of these sections will vary based on the complexity of the functionality
+being developed.
+ 
+## {Solution 2} 
+
+... 
+
+## {Solution N} 
+
+# Results 
+
+This section should contain a table that has each solution rated against each of the evaluation criteria: 
+
+|Solution|Evaluation Criteria 1|Evaluation Criteria 2|...|Evaluation Criteria N|
+|--------|---------------------|---------------------|---|---------------------|
+|Solution 1|||||
+|Solution 2|||||
+|...|||||
+|Solution M|||||
+
+Note: The formatting of the table can change. In the past, we have had success with qualitative descriptions
+in the table entries and color coding the cells to represent good, fair, bad. 
+
+# Decision 
+
+The chosen solution, or a list of questions that need to be answered before the decision can be made.  
+
+In the latter case, each question needs an action item and an assigned person for answering the question. 
+Once those questions are answered, the document must be updated to reflect the answers and the final decision 

--- a/design-reviews/trade-studies/template.md
+++ b/design-reviews/trade-studies/template.md
@@ -1,5 +1,7 @@
-This generic template can be used for any situation where we have a set of requirements that can be satisfied 
-by multiple solutions. They can range in scope from choice of which open source package to use through full 
+# Trade Study Template
+
+This generic template can be used for any situation where we have a set of requirements that can be satisfied
+by multiple solutions. They can range in scope from choice of which open source package to use through full
 architecture designs.  
 
 # Trade Study: {study name goes here} 


### PR DESCRIPTION
Trade Studies are a useful tool for walking through the design process. They create an objective set of criteria that represent the design requirements and measure possible designs against them. 

This PR migrates the existing documentation out of Artifact Hub and moves it into the playbook. The documentation has also been updated to show how trade studies work with Architecture Decision Records added by @hybridflux 