### PR TITLE
Included link to pair programming sessions

### DIFF
--- a/agile-development/collaboration/readme.md
+++ b/agile-development/collaboration/readme.md
@@ -73,4 +73,5 @@ Knowledge sharing and bringing CSE and customer engineers together in a ‘code-
 ## Resources
 
 - [On Pair Programming - Martin Fowler](https://martinfowler.com/articles/on-pair-programming.html)
-- [Pair Programming hands-on lessons](https://github.com/The-V8/pair-programming-sessions)
+
+- [Pair Programming hands-on lessons](https://github.com/The-V8/pair-programming-sessions) - these can be used (and adapted) to support bringing pair programming into your team (MS internal or including customers)

--- a/agile-development/collaboration/readme.md
+++ b/agile-development/collaboration/readme.md
@@ -69,3 +69,8 @@ As soon the pair finds out that the PBI will warrant swarming, the pair brings i
 ## Benefits of increased collaboration
 
 Knowledge sharing and bringing CSE and customer engineers together in a ‘code-with’ manner is an important aspect of CSE engagements. This grows both our customers’ and our CSE team’s capability to build on Azure. We are responsible for demonstrating engineering fundamentals and leaving the customer in a better place after we disengage. This can only happen if we collaborate and engage together as a team. In addition to improved software quality, this also adds a beneficial social aspect to the engagements.
+
+## Resources
+
+- [On Pair Programming - Martin Fowler](https://martinfowler.com/articles/on-pair-programming.html)
+- [Pair Programming hands-on lessons](https://github.com/The-V8/pair-programming-sessions)


### PR DESCRIPTION
Added links to pair programming hands-on sessions we've been running in multiple teams (either MS only or customer & MS joined teams) to increase use of pair programming, especially at the beginning of joint coding engagements.