### PR TITLE
Add markdown link checker - and fix broken links

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,3 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: '.markdownlinkcheck.json'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   lint:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js
@@ -20,3 +18,8 @@ jobs:
       run: |
         npm i
         npm run lint
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,11 @@
+{
+    "ignorePatterns": [
+        {"pattern": "^./INSERT_URL_TO_ISSUE"},
+        {"pattern": "^./link-to-the-work-item"},
+        {"pattern": "^https://portal.azure.com"},
+        {"pattern": "^http://link-to-feature-or-story-work-item"},
+        {"pattern": "^http://link-to-task-work-item"},
+        {"pattern": "^http://link-to-story-work-item"},
+        {"pattern": "^http://link-to-work-item"}
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ prompted the pull request.
 ### Merging strategy
 
 The preferred merging strategy for this repo is **linear**.
-You can familiarize yourself with [merging strategies](./source-control/contributing/readme.md#merge-strategies) described in the Source Control section of this repo.
+You can familiarize yourself with [merging strategies](./source-control/contributing/merge-strategies.md) described in the Source Control section of this repo.
 
 ## Adding a new section
 

--- a/ENG-FUNDAMENTALS-CHECKLIST.md
+++ b/ENG-FUNDAMENTALS-CHECKLIST.md
@@ -1,0 +1,95 @@
+# Engineering Fundamentals Checklist
+
+This checklist helps to ensure that our projects meet our Engineering Fundamentals.
+
+## Source Control
+
+- [ ] The main branch is locked.
+- [ ] Merges are done through PRs.
+- [ ] PRs reference related work items.
+- [ ] Commit history is consistent and commit messages are informative (what, why).
+- [ ] Secrets are not part of the commit history or made public. (see [Credential scanning](continuous-integration/credential-scanning/readme.md))
+- [ ] Public repositories follow the [OSS guidelines](source-control/readme.md#creating-a-new-repository), see `Required files in default branch for public repositories`.
+
+More details on [Source Control](source-control/readme.md)
+
+## Work Item Tracking
+
+- [ ] All items are tracked in AzDevOps (or similar).
+- [ ] The board is organized (swim lanes, feature tags, technology tags).
+
+## Testing
+
+- [ ] Unit tests cover the majority of all components (>90% if possible).
+- [ ] Integration tests run to test the solution e2e.
+
+More details on [Unit Testing](automated-testing/unit-testing/readme.md)
+More details on [Integration Testing](automated-testing/integration-testing/readme.md)
+
+## CI/CD
+
+- [ ] Project runs CI with automated build and test on each PR.
+- [ ] Project uses CD to manage deployments to a replica environment before PRs are merged.
+- [ ] Main branch is always shippable.
+
+## Security - TO DO
+
+- [ ] Access control.
+- [ ] Separation of concerns.
+- [ ] Robust treatment of secrets.
+- [ ] Encryption for data in transit (and if necessary at rest) and password hashing.
+
+## Observability
+
+- [ ] Significant business and functional events are tracked and related metrics collected.
+- [ ] Application faults and errors are logged.
+- [ ] Health of the system is monitored.
+- [ ] The client and server side observability data can be differentiated.
+- [ ] Logging configuration can be modified without code changes (eg: verbose mode).
+- [ ] [Incoming tracing context](observability/correlation-id.md) is propagated to allow for production issue debugging purposes.
+- [ ] GDPR compliance is ensured regarding PII (Personally Identifiable Information).
+
+## Agile/Scrum
+
+- [ ] Process Lead (fixed/rotating) to run standup daily.
+- [ ] Agile process clearly defined within team.
+- [ ] Dev Lead (+ PO/Others) have responsibility for backlog management and grooming.
+- [ ] Working agreement between members of team and customer.
+
+## Design Reviews
+
+- [ ] Process for conducting design reviews is included in the [Working Agreement](/agile-development/team-agreements/working-agreements/readme.md).
+- [ ] Design reviews for each major component of the solution are carried out and documented, including alternatives.
+- [ ] Stories and/or PRs link to the design document.
+- [ ] Each user story includes a task for design review by default, which is assigned or removed during sprint planning.
+- [ ] Project advisors are invited to design reviews or asked to give feedback to the design decisions captured in documentation.
+- [ ] Discover all the reviews that the customer's processes require and plan for them.
+
+More details on [Design Reviews](design-reviews/readme.md)
+
+## Code Reviews
+
+- [ ] Clear agreement in the team as to function of code reviews.
+- [ ] Code review checklist or established process.
+- [ ] A minimum number of reviewers (usually 2) for a PR merge is enforced by policy.
+- [ ] Linters/Code Analyzers, unit tests and successful builds for PR merges are set up.
+- [ ] Process to enforce a quick review turnaround.
+
+More details on [Code Reviews](code-reviews/README.md)
+
+## Retrospectives
+
+- [ ] Set time for retrospectives each week/at the end of each sprint.
+- [ ] 1-3 proposed experiments to be tried each week/sprint to improve the process.
+- [ ] Experiments have owners and are added to project backlog.
+- [ ] Longer retrospective for Milestones and project completion.
+
+More details on [Retrospectives](agile-development/retrospectives/readme.md)
+
+## Engineering Feedback
+
+- [ ] Submit business and technical blockers that prevent project success
+- [ ] Add suggestions for improvements to leveraged services and components
+- [ ] Ensure feedback is detailed and repeatable
+
+More details on [Engineering Feedback](engineering-feedback/readme.md)

--- a/agile-development/team-agreements/definition-of-ready/readme.md
+++ b/agile-development/team-agreements/definition-of-ready/readme.md
@@ -37,6 +37,6 @@ The ready checklist should contain items that apply broadly. Don't include items
 
 In the case that the highest priority work is not yet ready, it still may be possible to make forward progress. Here are some strategies that may help:
 
-* [Backlog Refinement](/agile-development/backlog-management/refinement/readme.md) sessions are a good time to validate that high priority user stories are verified to have a clear description, acceptance criteria and demonstrable business value. It is also a good time to breakdown large stories will likely not be completable in a single sprint.
+* [Backlog Refinement](../../backlog-management/refinement/readme.md) sessions are a good time to validate that high priority user stories are verified to have a clear description, acceptance criteria and demonstrable business value. It is also a good time to breakdown large stories will likely not be completable in a single sprint.
 * Prioritization sessions are a good time to prioritize user stories that unblock other blocked high priority work.
 * Blocked user stories can often be broken down in a way that unblocks a portion of the original stories scope. This is a good way to make forward progress even when some work is blocked.

--- a/automated-testing/readme.md
+++ b/automated-testing/readme.md
@@ -53,6 +53,6 @@ To use the table, either eyeball-browse or search for keywords.  The
 - [Integration testing](integration-testing/readme.md)
 - [Performance testing](performance-testing/readme.md)
 - [Smoke testing](smoke-testing/readme.md)
-- [Synthetic Transaction testing](synthetic-Monitoring-tests/readme.md)
+- [Synthetic Transaction testing](synthetic-monitoring-tests/readme.md)
 - [UI testing](ui-testing/readme.md)
 - [Unit testing](unit-testing/readme.md)

--- a/code-reviews/pull-request-template.md
+++ b/code-reviews/pull-request-template.md
@@ -27,7 +27,7 @@
 - If you are printing something show a screenshot
 - When you want to share long logs upload to:
 
-  (StorageAccount)/pr-support/attachments/(PR Number)/(yourFiles) using [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) or [portal.azure.com](portal.azure.com) and insert the link here.
+  (StorageAccount)/pr-support/attachments/(PR Number)/(yourFiles) using [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) or [portal.azure.com](https://portal.azure.com) and insert the link here.
 
 ### Other information or known dependencies
 

--- a/code-reviews/recipes/Bash.md
+++ b/code-reviews/recipes/Bash.md
@@ -132,8 +132,6 @@ fi
 
 ## Code Review Checklist
 
-In addition to the [Code Review Checklist](../README.md) you should also look for these bash specific code review items
-
 * [ ] Does this code use [Built-in Shell](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) Options like set -o, set -e, set -u for execution control of shell scripts ?
 * [ ] Is the code modularized? Shell scripts can be modularized like python modules. Portions of bash scripts should be sourced in complex bash projects.
 * [ ] Are all exceptions handled correctly? Exceptions should be handled correctly using exit codes or trapping signals.

--- a/code-reviews/recipes/Go.md
+++ b/code-reviews/recipes/Go.md
@@ -143,7 +143,7 @@ steps:
 
 ## Code Review Checklist
 
-The Go language team maintains a list of common [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) for go that form the basis for a solid checklist for a team working in Go that should be followed in addition to the [CSE Code Review Checklist](../README.md)
+The Go language team maintains a list of common [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) for go that form the basis for a solid checklist for a team working in Go.
 
 * [ ] Does this code [handle errors](https://golang.org/doc/effective_go.html#errors) correctly? This includes not throwing away errors with `_` assignments and returning errors, instead of [in-band error values](https://github.com/golang/go/wiki/CodeReviewComments#in-band-errors)?
 * [ ] Does this code follow Go standards for method [receiver types](https://github.com/golang/go/wiki/CodeReviewComments#receiver-type)?

--- a/code-reviews/recipes/Markdown.md
+++ b/code-reviews/recipes/Markdown.md
@@ -87,7 +87,7 @@ The [`markdownlint extension`](https://marketplace.visualstudio.com/items?itemNa
 
 ## Build validation
 
-To automate linting with `markdownlint` for PR [validation in GitHub actions](.github\workflows\markdownlint.yml) as we do in this repo, use the following YAML.
+To automate linting with `markdownlint` for PR [validation in GitHub actions](../../.github/workflows/markdownlint.yml)(.github\workflows\markdownlint.yml) as we do in this repo, use the following YAML.
 
 ```yaml
 name: Markdownlint
@@ -118,8 +118,6 @@ jobs:
 ```
 
 ## Code Review Checklist
-
-Apart from the items on the [Code Review Checklist](../README.md) you should also look for these markdown specific code review items
 
 - [ ] Is the document easy to read and understand and does it follow [good writing guidelines](#writing-style-guidelines)?
 - [ ] Is there a single source of truth or is content repeated in more than one document?

--- a/code-reviews/recipes/Python.md
+++ b/code-reviews/recipes/Python.md
@@ -214,8 +214,6 @@ At the next attempted commit any lint failures will block the commit.
 
 ## Code Review Checklist
 
-In addition to the [Code Review Checklist](../README.md) you should also look for these python specific code review items
-
 * [ ] Are all new packages used included in requirements.txt
 * [ ] Does the code pass all lint checks?
 * [ ] Do functions use type hints, and are there any type hint errors?

--- a/code-reviews/recipes/Terraform.md
+++ b/code-reviews/recipes/Terraform.md
@@ -67,8 +67,6 @@ terraform validate
 
 ## Code Review Checklist
 
-In addition to the [Code Review Checklist](../readme.md) you should also look for these Terraform specific code review items
-
 * [ ] Are all providers used in the terraform scripts [versioned](https://www.terraform.io/docs/configuration/providers.html#provider-versions) to prevent breaking changes in the future?
 * [ ] Are modules split into separate `.tf` files where appropriate?
 * [ ] Does the repository contain a `README.md` describing the architecture provisioned?

--- a/code-reviews/recipes/javascript-and-typescript.md
+++ b/code-reviews/recipes/javascript-and-typescript.md
@@ -143,8 +143,6 @@ As an alternative [husky](https://github.com/typicode/husky) can be considered t
 
 ## Code Review Checklist
 
-In addition to the [Code Review checklist](../README.md), you should also look for these additional JavaScript related code review items:
-
 * [ ] Does the code stick to our formatting and code standards? Does running prettier and ESLint over the code should yield no warnings or errors respectively?
 * [ ] Does the change re-implement code that would be better served by pulling in a well known module from the ecosystem?
 * [ ] Does TypeScript code compile without raising linting errors

--- a/continuous-delivery/recipes/github-workflows/workflow-per-environment.md
+++ b/continuous-delivery/recipes/github-workflows/workflow-per-environment.md
@@ -16,8 +16,6 @@ One way to get around the complexity of a single workflow is to have separate wo
 
 ![Workflow-Designs-Independent-Workflows](./assets/Workflow-Designs-Independent-Workflows.png)
 
-An example of initializing workflows to deploy, in an automated way, for each environment can be seen [here](https://github.com/microsoft/github-workflow-initialization)
-
 ## References
 
 - [GitHub Actions](https://docs.github.com/en/actions)

--- a/data-fundamentals/README.md
+++ b/data-fundamentals/README.md
@@ -74,5 +74,5 @@ Monitor infrastructure, pipelines and data
 
 The [DataOps for the Modern Data Warehouse repo](https://github.com/Azure-Samples/modern-data-warehouse-dataops) contains both end-to-end and technology specific samples on how to implement DataOps on Azure.
 
-![CI/CD](CI_CD_process.PNG?raw=true "CI/CD")
+![CI/CD](CI_CD_process.png "CI/CD")
 Image: CI/CD for Data pipelines on Azure - from DataOps for the Modern Data Warehouse repo

--- a/design-reviews/recipes/high-level-design-recipe.md
+++ b/design-reviews/recipes/high-level-design-recipe.md
@@ -6,7 +6,7 @@ Design at macroscopic level shows the interactions between systems and services 
 
 ## Things to keep in mind
 
-* As with all other aspects of the project, design reviews must provide a friendly and safe environment so that any team member feels comfortable proposing a design for review and can use the opportunity to grow and learn from the constructive / non-judgemental feedback from peers and subject matter experts (see [Team Agreements](../../team-agreements)).
+* As with all other aspects of the project, design reviews must provide a friendly and safe environment so that any team member feels comfortable proposing a design for review and can use the opportunity to grow and learn from the constructive / non-judgemental feedback from peers and subject matter experts (see [Team Agreements](../../agile-development/team-agreements/readme.md)).
 * Attempt to illustrate different personas involved in the use cases and how/which boxes are their entry points.
 * Prefer pictures over paragraphs. The diagrams aren't intended to generate code so they should be fairly high level.
   * Artifacts should indicate the direction of calls (are they outbound, inbound, or bidirectional?) and call out system boundaries where ports might need to be opened or additional infrastructure work may be needed to allow calls to be made.

--- a/ml-fundamentals/ml-project-management.md
+++ b/ml-fundamentals/ml-project-management.md
@@ -27,7 +27,7 @@ Within this framework, the team follows these Agile ceremonies:
     - Working code (e.g. models, pipelines, exploratory code)
     - Documentation of new hypotheses, and the acceptance or rejection of previous hypotheses as part of a Hypothesis Driven Analysis (HDA). See more resources on HDA here:
         1. [HDA](https://datasciencevademecum.com/2015/11/10/agile-data-science-iteration-0-the-hypothesis-driven-analysis) (from the Data Science Vademecum website).
-        2. [Hypothesis Driven Development](https://barryoreilly.com/how-to-implement-hypothesis-driven-development) (from Barry Oreilly's website).
+        2. [Hypothesis Driven Development](https://barryoreilly.com/explore/blog/how-to-implement-hypothesis-driven-development/) (from Barry Oreilly's website).
     - Exploratory Data Analysis (EDA) results and learnings documented
 
 2. User stories and spikes are usually estimated using [T-shirt sizes](../agile-development/sprint-planning/estimation/readme.md#t-shirt-sizes) or similar, and not in actual days/hours. See more [here](../agile-development/sprint-planning/estimation/readme.md) on story estimation.

--- a/source-control/git-guidance/readme.md
+++ b/source-control/git-guidance/readme.md
@@ -111,7 +111,7 @@ To avoid loosing work, it is good to commit often in small chunks. This allows y
 
 ## Merging
 
-In [CSE](..\..\CSE.md) we encourage the use of Pull Request to merge code to the main repository to make sure that all code in the final product is [code reviewed](..\..\code-reviews\readme.md)
+In [CSE](../../CSE.md) we encourage the use of Pull Request to merge code to the main repository to make sure that all code in the final product is [code reviewed](../../code-reviews/readme.md)
 
 The Pull Request (PR) process in [Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/repos/git/pull-requests?view=azure-devops), [GitHub](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) and other similar tools make it easy both to start a PR, review a PR and merge a PR.
 

--- a/source-control/pull-request-templates/README.md
+++ b/source-control/pull-request-templates/README.md
@@ -20,8 +20,8 @@ It is also worth noting that the rendering of markdown is different between Azur
 ### Example Templates
 
 - [Default Pull Request](./github/github-template.md)
-- [Bug Pull Request](./github/github-arch-design-pr-template.md)
-- [Feature Pull Request](./github/github-arch-design-pr-template.md)
+- [Bug Pull Request](./github/github-bug-pr-template.md)
+- [Feature Pull Request](./github/github-feature-pr-template.md)
 
 ## Azure DevOps
 
@@ -41,5 +41,5 @@ It is worth noting that though technically you can put your templates in `docs` 
 ### Example Templates
 
 - [Default Pull Request](./azure-devops/azure-devops-template.md)
-- [Bug Pull Request](./azure-devops/azure-devops-arch-design-pr-template.md)
-- [Feature Pull Request](./azure-devops/azure-devops-arch-design-pr-template.md)
+- [Bug Pull Request](./azure-devops/azure-devops-bug-pr-template.md)
+- [Feature Pull Request](./azure-devops/azure-devops-feature-pr-template.md)

--- a/source-control/readme.md
+++ b/source-control/readme.md
@@ -1,6 +1,6 @@
 # Source Control
 
-There are many different options when working with Source Control. In [CSE](../CSE.md) we use [AzureDevOps](https://csesd.visualstudio.com/_projects) for private repositories and [GitHub](https://github.com/) for public repositories.
+There are many different options when working with Source Control. In [CSE](../CSE.md) we use [AzureDevOps](https://azure.microsoft.com/en-us/services/devops/) for private repositories and [GitHub](https://github.com/) for public repositories.
 
 ## Sections within Source Control
 


### PR DESCRIPTION
This PR adds a markdown link checker that checks for broken links.
It also fixes all the current broken links in the repo by either
1. replacing them with a correct link or
2. removing the sentence if the link no longer exists