### PR TITLE
502 - Adding "Agility Team Manifesto" and methods md

### DIFF
--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -10,7 +10,7 @@ A team manifesto is a soft contract among team members which summarizes the basi
 
 It aims to reduce the time on setting the right expectations and providing a consensus among team members as well as clarifying the question of "How does the new team develop the software?"
 
-Another main goal of the manifesto is providing a discussion environment during "manifesto building session" and detect the gaps/differences in certain topics for each member during these discussions.
+Another main goal of writing the manifesto is to start a conversation during the "manifesto building session" to detect any differences of opinion around how the team should work.
 
 It also serves in the same way when a new team member joins to the team. It gives a short summary of standards and if the new team member asks any question about any topic, this is a good thing to understand the improvement area and take the required actions.
 
@@ -24,11 +24,13 @@ If there is a need for providing knowledge on certain topics, the way to do is d
 A few important points about the team manifesto
 
 - The team manifesto is built by the team itself
-- It can include any technical or behavioural agility topics as soon as team find it relevant
+- It can include any technical or behavioral agility topics that the team finds relevant
 - It aims to give a common understanding about the desired expertise, practices and/or behaviors within the team
 - Based on the needs of the team and retrospective results, it can be modified during the engagement.
-In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping them to reach their highest potential.
-The difference of team manifesto from other comprehensive set of standards/practices documents is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts with open discussion environment in an ice-breaker way.
+
+In CSE, we aim for quality over quantity, and well-crafted software as well as to a comfortable/transparent environment where each team member can reach their highest potential.
+
+The difference between the team manifesto and other team documents is that it is used to give a short summary of expectations around the technical way of working and supported mindset in the team, before code-with sprints starts.
 
 Below, you can find some including, but not limited, topics many teams touch during engagements,
 
@@ -38,7 +40,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Respect | Any preferred statement about it's a "must-have" team value |
 | Collaboration | Any preferred statement about how does team want to collaborate ? |
 | Transparency | A simple statement about it's a "must-have" team value and if preferred, how does this being provided by the team ? meetings, retrospective, feedback mechanisms ..etc. |
-| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them? |
+| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them? 
 | PR sizing | What does team prefer in PRs ? |
 | Branching | Team's branching strategy and standards |
 | Commit standards | Preferred format in commit messages, rules and more |
@@ -46,7 +48,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Pair/Mob Programming | Will team apply pair/mob programming ? If yes, what programming styles are suitable for the team ? |
 | Release Process | Principles around release process such as quality gates, reviewing process ...etc. |
 | Code Review | Any rule for code reviewing such as min number of reviewers, team rules ...etc. |
-| Action Readiness | How the backlog will be refined ? What will be the way for clear DoD and ACs ? |
+| Action Readiness | How the backlog will be refined? How do we ensure clear Definition of Done and Acceptance Criteria ? |
 | TDD | Will the team follow TDD ? |
 | Test Coverage | Is there any expected number, percentage or measurement ?  |
 | Dimensions in Testing | Required tests for high quality software, eg : unit, integration, functional, performance, regression, acceptance |

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -50,7 +50,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Commit standards | Preferred format in commit messages, rules and more |
 | Clean Code | Does team follow clean code principles ? |
 | Pair/Mob Programming | Will team apply pair/mob programming ? If yes, what programming styles are suitable for the team ? |
-| Release Process | Principles around release proicess such as quality gates, reviewing process ...etc. |
+| Release Process | Principles around release process such as quality gates, reviewing process ...etc. |
 | Code Review | Any rule for code reviewing such as min number of reviewers, team rules ...etc. |
 | Action Readiness | How the backlog will be refined ? What will be the way for clear DoD and ACs ? |
 | TDD | Will team follow TDD ? |

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -40,7 +40,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Respect | Any preferred statement about it's a "must-have" team value |
 | Collaboration | Any preferred statement about how does team want to collaborate ? |
 | Transparency | A simple statement about it's a "must-have" team value and if preferred, how does this being provided by the team ? meetings, retrospective, feedback mechanisms ..etc. |
-| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them? 
+| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them?
 | PR sizing | What does team prefer in PRs ? |
 | Branching | Team's branching strategy and standards |
 | Commit standards | Preferred format in commit messages, rules and more |

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -20,19 +20,19 @@ It also serves in the same way when a new team member joins to the team. It give
 It can be said that the best time to start building it is at the very early phase of the engagement when teams meet with each other for swarming or during the preparation phase.
 
 It is recommended to keep team manifesto as simple as possible, so preferably, one-page simple document which **doesn't include any references or links** is a nice format for it.
-If there is a need for providing knowledge on certain topics, the way to do is delivering brown-bag sessions, technical katas, practices documentations and others later on.
+If there is a need for providing knowledge on certain topics, the way to do is delivering brown-bag sessions, technical katas, team practices, documentations and others later on.
 
 A few important points about team manifesto;
 
 - Team manifesto is built by the **team itself**
 
-- It can include any technical or behavioural agility topics as soon as team find it relevant,
+- It can include any technical or behavioural agility topics as soon as team find it relevant
 
 - It aims to have a common understanding about the desired expertise, practices and/or behaviours within the team
 
 - Based on the needs of the team and retrospective results, it can be modified during the engagement.
 
-In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping her/him to reach her/his highest potential.
+In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping them to reach their highest potential.
 
 The difference of team manifesto from other comprehensive set of standards/practices documents is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts with open discussion environment in an ice-breaker way.
 
@@ -52,7 +52,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Pair/Mob Programming | Will team apply pair/mob programming ? If yes, what programming styles are suitable for the team ? |
 | Release Process | Principles around release proicess such as quality gates, reviewing process ...etc. |
 | Code Review | Any rule for code reviewing such as min number of reviewers, team rules ...etc. |
-| Action Readiness | How the backlog will be groomed ? What will be the way for clear DoD and ACs ? |
+| Action Readiness | How the backlog will be refined ? What will be the way for clear DoD and ACs ? |
 | TDD | Will team follow TDD ? |
 | Test Coverage | Is there any expected number, percentage or measurement ?  |
 | Dimensions in Testing | Required tests for high quality software, eg : unit, integration, functional, performance, regression, acceptance |
@@ -67,11 +67,11 @@ Below, you can find some including, but not limited, topics many teams touch dur
 ## Tools
 
 Generally team sessions are enough for building a manifesto and having a consensus around it.
-And if there is a need for improving it in a structured way, [This guy, That guy*](https://www.scrum.nl/blog/building-team-manifesto/) or other retrospective tools can be used.
+And if there is a need for improving it in a structured way, [Building a Team Manifesto](https://www.scrum.nl/blog/building-team-manifesto/) or any retrospective tool can be used.
 
 ## Resources
 
-[This guy, That guy*](https://www.scrum.nl/blog/building-team-manifesto/)
+[Building a Team Manifesto*](https://www.scrum.nl/blog/building-team-manifesto/)
 
 [Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
 

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -40,7 +40,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Respect | Any preferred statement about it's a "must-have" team value |
 | Collaboration | Any preferred statement about how does team want to collaborate ? |
 | Transparency | A simple statement about it's a "must-have" team value and if preferred, how does this being provided by the team ? meetings, retrospective, feedback mechanisms ..etc. |
-| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them?
+| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them? |
 | PR sizing | What does team prefer in PRs ? |
 | Branching | Team's branching strategy and standards |
 | Commit standards | Preferred format in commit messages, rules and more |

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -6,13 +6,13 @@ CSE teams work with a new development team in each customer engagement which req
 
 Completion of this phase of ice-breakers and discussions around the standards takes time, but is required to start increasing the learning curve of the new team.
 
-A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about expectations from each team member in order to deliver high quality output at the end of each engagement.
+A team manifesto is a light-weight one page agile document among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about technical expectations from each team member in order to deliver high quality output at the end of each engagement.
 
-It aims to reduce the time on setting the right expectations and providing a consensus among team members as well as clarifying the question of "How does the new team develop the software?"
+It aims to reduce the time on setting the right expectations without arranging longer "team document reading" meetings and provid a consensus among team members to answer the question - "How does the new team develop the software?" - by covering all engineering fundamentals and excellence topics such as release process, clean coding, testing.
 
 Another main goal of writing the manifesto is to start a conversation during the "manifesto building session" to detect any differences of opinion around how the team should work.
 
-It also serves in the same way when a new team member joins to the team. It gives a short summary of standards and if the new team member asks any question about any topic, this is a good thing to understand the improvement area and take the required actions.
+It also serves in the same way when a new team member joins to the team. New joiners can quickly get up to speed on the agreed standards.
 
 ## How to Build a Team Manifesto
 
@@ -23,9 +23,9 @@ If there is a need for providing knowledge on certain topics, the way to do is d
 
 A few important points about the team manifesto
 
-- The team manifesto is built by the team itself
-- It can include any technical or behavioral agility topics that the team finds relevant
-- It aims to give a common understanding about the desired expertise, practices and/or behaviors within the team
+- The team manifesto is built by the development team itself
+- It should cover all required technical engineering points for the excellence as well as behavioral agility mindset items that the team finds relevant
+- It aims to give a common understanding about the desired expertise, practices and/or mindset within the team
 - Based on the needs of the team and retrospective results, it can be modified during the engagement.
 
 In CSE, we aim for quality over quantity, and well-crafted software as well as to a comfortable/transparent environment where each team member can reach their highest potential.

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -1,14 +1,19 @@
 # Team Manifesto
 
-In Microsoft, CSE teams work with a new development team in each customer engagement so there is a phase of introduction & knowledge transfer before starting an engagement which takes some time to exchange ideas around the way of working and standards in order to increase the learning curve of the new team.
+## Introduction
+
+CSE teams work with a new development team in each customer engagement which requires a phase of introduction & knowledge transfer before starting an engagement.
+
+Completion of this phase of ice-breakers and discussions around the standards takes time however also required to start increasing the learning curve of the new team.
 
 A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about
 expectations from each team member in order to deliver high quality output at the end of each engagement.
 
-One of the main goal of team manifesto is providing a discussion environment during the team session for building it and detects the gaps/differences in certain topics for each member.
-It also serves in the same way when a new team member joins to the team. So if a new team member reads the document and asks a question about any topic, this is a good thing to detect the improvement area and take the required actions.
+It aims to reduce the time on setting the right expectations and providing a consensus among team members as well as clarifying the question of "How does the new team develop the software?"
 
-Nearly in every engagement, teams create multiple standards/practices documents to give more comprehensive information on certain topics. The difference of team manifesto is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts.
+Another main goal of the manifesto is providing a discussion environment during "manifesto building session" and detect the gaps/differences in certain topics for each member during these discussions.
+
+It also serves in the same way when a new team member joins to the team. It gives a short summary of standards and if the new team member asks any question about any topic, this is a good thing to understand the improvement area and take the required actions.
 
 ## How to Build a Team Manifesto
 
@@ -28,6 +33,8 @@ A few important points about team manifesto;
 - Based on the needs of the team and retrospective results, it can be modified during the engagement.
 
 In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping her/him to reach her/his highest potential.
+
+The difference of team manifesto from other comprehensive set of standards/practices documents is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts with open discussion environment in an ice-breaker way.
 
 Below, you can find some including, but not limited, topics many teams touch during engagements,
 

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -1,0 +1,71 @@
+# Team Manifesto
+
+In Microsoft, CSE teams work with a new development team in each customer engagement so there is a phase of introduction & knowledge transfer before starting an engagement which takes some time to exchange ideas around the way of working and standards in order to increase the learning curve of the new team.
+
+A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about
+expectations from each team member in order to deliver high quality output at the end of each engagement.
+
+One of the main goal of team manifesto is providing a discussion environment during the team session for building it and detects the gaps/differences in certain topics for each member.
+It also serves in the same way when a new team member joins to the team. So if a new team member reads the document and asks a question about any topic, this is a good thing to detect the improvement area and take the required actions.
+
+Nearly in every engagement, teams create multiple standards/practices documents to give more comprehensive information on certain topics. The difference of team manifesto is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts.
+
+## How to Build a Team Manifesto
+
+It can be said that the best time to start building it is at the very early phase of the engagement when teams meet with each other for swarming or during the preparation phase.
+
+It is recommended to keep team manifesto as simple as possible, so preferably, one-page simple document which **doesn't include any references or links** is a nice format for it.
+If there is a need for providing knowledge on certain topics, the way to do is delivering brown-bag sessions, technical katas, practices documentations and others later on.
+
+A few important points about team manifesto;
+
+- Team manifesto is built by the **team itself**
+
+- It can include any technical or behavioural agility topics as soon as team find it relevant,
+
+- It aims to have a common understanding about the desired expertise, practices and/or behaviours within the team
+
+- Based on the needs of the team and retrospective results, it can be modified during the engagement.
+
+In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping her/him to reach her/his highest potential.
+
+Below, you can find some including, but not limited, topics many teams touch during engagements,
+
+| Topic | What is it about ? |
+|-|-|
+| Collective Ownership | Does team own the code rather than individuals? And what is the expectation? |
+| Respect | Any preferred statement about it's a "must-have" team value |
+| Collaboration | Any preferred statement about how does team want to collaborate ? |
+| Transparency | A simple statement about it's a "must-have" team value and if preferred, how does this being provided by the team ? meetings, retrospective, feedback mechanisms ..etc. |
+| Craftpersonship | Which tools such as Git, VS Code LiveShare, ..etc. are being used ? What is the definition of expected best usage of them? |
+| PR sizing | What does team prefer in PRs ? |
+| Branching | Team's branching strategy and standards |
+| Commit standards | Preferred format in commit messages, rules and more |
+| Clean Code | Does team follow clean code principles ? |
+| Pair/Mob Programming | Will team apply pair/mob programming ? If yes, what programming styles are suitable for the team ? |
+| Release Process | Principles around release proicess such as quality gates, reviewing process ...etc. |
+| Code Review | Any rule for code reviewing such as min number of reviewers, team rules ...etc. |
+| Action Readiness | How the backlog will be groomed ? What will be the way for clear DoD and ACs ? |
+| TDD | Will team follow TDD ? |
+| Test Coverage | Is there any expected number, percentage or measurement ?  |
+| Dimensions in Testing | Required tests for high quality software, eg : unit, integration, functional, performance, regression, acceptance |
+| Build process | build for all? or not; The clear statement of where code and under what conditions code should work ? eg : OS, DevOps, tool dependency |
+| Bug fix | The rules of bug fixing in the team ? eg: contact people, attaching PR to the issue ..etc. |
+| Technical debt | How does team manage/follow it?  |
+| Refactoring | How does team manage/follow it? |
+| Agile Documentation | Does team want to use diagrams and tables more rather than detailed KB articles ? |
+| Efficient Documentation | When is it necessary ? Is it a prerequisite to complete tasks/PRs ..etc.? |
+| Definition of Fun | How will we have fun for relaxing/enjoying the team spirit during the engagement? |
+
+## Tools
+
+Generally team sessions are enough for building a manifesto and having a consensus around it.
+And if there is a need for improving it in a structured way, [This guy, That guy*](https://www.scrum.nl/blog/building-team-manifesto/) or other retrospective tools can be used.
+
+## Resources
+
+[This guy, That guy*](https://www.scrum.nl/blog/building-team-manifesto/)
+
+[Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
+
+[Team Building and Retrospective activities*](https://www.funretrospectives.com/category/team-building/)

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -4,7 +4,7 @@
 
 CSE teams work with a new development team in each customer engagement which requires a phase of introduction & knowledge transfer before starting an engagement.
 
-Completion of this phase of ice-breakers and discussions around the standards takes time however also required to start increasing the learning curve of the new team.
+Completion of this phase of ice-breakers and discussions around the standards takes time, but is required to start increasing the learning curve of the new team.
 
 A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about
 expectations from each team member in order to deliver high quality output at the end of each engagement.
@@ -22,18 +22,13 @@ It can be said that the best time to start building it is at the very early phas
 It is recommended to keep team manifesto as simple as possible, so preferably, one-page simple document which **doesn't include any references or links** is a nice format for it.
 If there is a need for providing knowledge on certain topics, the way to do is delivering brown-bag sessions, technical katas, team practices, documentations and others later on.
 
-A few important points about team manifesto;
+A few important points about the team manifesto
 
-- Team manifesto is built by the **team itself**
-
+- The team manifesto is built by the team itself
 - It can include any technical or behavioural agility topics as soon as team find it relevant
-
-- It aims to have a common understanding about the desired expertise, practices and/or behaviours within the team
-
+- It aims to give a common understanding about the desired expertise, practices and/or behaviors within the team
 - Based on the needs of the team and retrospective results, it can be modified during the engagement.
-
 In Microsoft, we have certain standards to build high quality and well-crafted software as well as to give comfortable/transparent environment to each team member for helping them to reach their highest potential.
-
 The difference of team manifesto from other comprehensive set of standards/practices documents is, it is used to give a short summary of the upcoming way of working and practices to prepare a base before deep dive starts with open discussion environment in an ice-breaker way.
 
 Below, you can find some including, but not limited, topics many teams touch during engagements,
@@ -53,7 +48,7 @@ Below, you can find some including, but not limited, topics many teams touch dur
 | Release Process | Principles around release process such as quality gates, reviewing process ...etc. |
 | Code Review | Any rule for code reviewing such as min number of reviewers, team rules ...etc. |
 | Action Readiness | How the backlog will be refined ? What will be the way for clear DoD and ACs ? |
-| TDD | Will team follow TDD ? |
+| TDD | Will the team follow TDD ? |
 | Test Coverage | Is there any expected number, percentage or measurement ?  |
 | Dimensions in Testing | Required tests for high quality software, eg : unit, integration, functional, performance, regression, acceptance |
 | Build process | build for all? or not; The clear statement of where code and under what conditions code should work ? eg : OS, DevOps, tool dependency |
@@ -72,7 +67,5 @@ And if there is a need for improving it in a structured way, [Building a Team Ma
 ## Resources
 
 [Building a Team Manifesto*](https://www.scrum.nl/blog/building-team-manifesto/)
-
-[Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
-
-[Team Building and Retrospective activities*](https://www.funretrospectives.com/category/team-building/)
+- [Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
+- [Team Building and Retrospective activities*](https://www.funretrospectives.com/category/team-building/)

--- a/agile-development/team-agreements/team-manifesto/readme.md
+++ b/agile-development/team-agreements/team-manifesto/readme.md
@@ -6,8 +6,7 @@ CSE teams work with a new development team in each customer engagement which req
 
 Completion of this phase of ice-breakers and discussions around the standards takes time, but is required to start increasing the learning curve of the new team.
 
-A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about
-expectations from each team member in order to deliver high quality output at the end of each engagement.
+A team manifesto is a soft contract among team members which summarizes the basic principles and values of the team and aiming to provide a consensus about expectations from each team member in order to deliver high quality output at the end of each engagement.
 
 It aims to reduce the time on setting the right expectations and providing a consensus among team members as well as clarifying the question of "How does the new team develop the software?"
 
@@ -67,5 +66,7 @@ And if there is a need for improving it in a structured way, [Building a Team Ma
 ## Resources
 
 [Building a Team Manifesto*](https://www.scrum.nl/blog/building-team-manifesto/)
-- [Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
-- [Team Building and Retrospective activities*](https://www.funretrospectives.com/category/team-building/)
+
+[Technical Agility*](https://v46.scaledagileframework.com/team-and-technical-agility/)
+
+[Team Building and Retrospective activities*](https://www.funretrospectives.com/category/team-building/)


### PR DESCRIPTION
A new doc is added agile-development/team-agreements/ 
which is also an item in https://cwcwiki.com/wiki/Agile_debugging_guidelines created by @meulta 

Kindly review the typo, grammar, lackness of clarification ..etc. issues and more if necessary, 

thanks in advance,
G.