### PR TITLE
Fix broken link in README.md to Engineering Fundamentals Checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A [breakdown of sections](SPRINT-STRUCTURE.md) according to the structure of an 
 
 ## QuickLinks
 
-* [Engineering Fundamentals Checklist](Engineering Fundamentals Checklist.md)
+* [Engineering Fundamentals Checklist](ENG-FUNDAMENTALS-CHECKLIST.md)
 * [Structure of a Sprint](SPRINT-STRUCTURE.md)
 
 ## Engineering Fundamentals


### PR DESCRIPTION
Fix broken link in the `README.md` file to the **Engineering Fundamentals Checklist** in the **QuickLinks** section.