### PR TITLE
Add optional social question to stand-up

### DIFF
--- a/agile-development/stand-ups/readme.md
+++ b/agile-development/stand-ups/readme.md
@@ -1,10 +1,11 @@
 # Stand-ups
 
-The stand-up is a time-boxed ceremony that is held each day of the sprint. In this ceremony, each contributor in the Development Team will answer three simple questions. This will repeat until each contributor has answered the three following questions.
+The stand-up is a time-boxed ceremony that is held each day of the sprint. In this ceremony, each contributor in the Development Team will answer three simple project questions and an optional social question. This will repeat until each contributor has answered the following questions.
 
 1. What did you work on yesterday that contributes to meet the sprint goal?
 2. What are you working on today that will contribute to meet the sprint goal?
 3. Do you have any impediments/blockers or need any help? (defer discussion / resolution to "the parking lot", described below)
+4. An [optional social question](./social-question/readme.md), e.g. "would you rather see the past or the future?"
 
 During the stand-up, additional discussions may arise. Make sure that someone adds them to the parking lot for after meeting discussion.  
 
@@ -19,6 +20,7 @@ The participation in the parking lot discussion is optional for all members exce
 
 1. Bring awareness of the progress done towards the sprint goal and the sprint backlog.
 2. Surface any impediments to one or more team members' contributions.
+3. Maintain contact between remote team members to reduce social barriers to collaboration.
 
 ## Participation
 
@@ -39,7 +41,7 @@ Both stand-up length and time to start are important as the stand-up has to be s
 
 ### Stand-up Length
 
-While the length can depend on the team size, if everyone is sticking to one line answers to the 3 key questions, it should be fairly easy to conclude within 5-10 minutes.
+While the length can depend on the team size, if everyone is sticking to one line answers to the key questions, it should be fairly easy to conclude within 5-10 minutes.
 
 #### Example (team size == ~8)
 
@@ -78,11 +80,15 @@ If a contributor is not working on an existing sprint task they need to either c
 
 ### Parking Lot Discussion Items
 
-As contributors are answering the three questions, if another contributor has a question or issue to share, they should reserve until after all contributors have answered finished. Once each member has answered all three questions, the Process Lead should open up the floor to anyone who may have an open question or unresolved issue to share. This portion of the ceremony is often referred to as the "Parking Lot".
+As contributors are answering the questions, if another contributor has a question or issue to share, they should reserve until after all contributors have finished answering. Once each member has answered all questions, the Process Lead should open up the floor to anyone who may have an open question or unresolved issue to share. This portion of the ceremony is often referred to as the "Parking Lot".
 
 > Parking lot discussions are optional for participants.
 
 Ensure discussion leaders call out necessary parties for their discussion points upfront, allowing those not needed to leave the meeting.
+
+### Social question
+
+Teams are frequently geographically distributed and include members who have not worked on projects together previously. Small social interactions facilitate interpersonal trust development and lower the barriers to collaboration. A social question-of-the-day that has a one-sentence answer contributes to trust development over the course of many stand-ups, with a minimal additional time commitment. The answer to the social question should be brief and follow the project questions answer. The facilitator may choose the social question or take a suggestion from the room. Description of what makes a good question and a list of starter questions are available within the [social question readme](./social-question/readme.md).
 
 ### Start On Time
 

--- a/agile-development/stand-ups/readme.md
+++ b/agile-development/stand-ups/readme.md
@@ -88,11 +88,11 @@ Ensure discussion leaders call out necessary parties for their discussion points
 
 ### Social question
 
-Teams are frequently geographically distributed and include members who have not worked on projects together previously. Small social interactions facilitate interpersonal trust development and lower the barriers to collaboration. A social question-of-the-day that has a one-sentence answer contributes to trust development over the course of many stand-ups, with a minimal additional time commitment. The answer to the social question should be brief and follow the project questions answer. The facilitator may choose the social question or take a suggestion from the room. Description of what makes a good question and a list of starter questions are available within the [social question readme](./social-question/readme.md).
+Teams are frequently geographically distributed and include members who have not worked on projects together previously. Social interactions facilitate the development of trust between team members and lower the barriers to collaboration. A social question-of-the-day that has a one-sentence answer contributes to trust development over the course of many stand-ups, with a minimal additional time commitment. The answer to the social question should be brief and follow the project questions answer. The facilitator may choose the social question or take a suggestion from the room. Description of what makes a good question and a list of starter questions are available within the [social question readme](./social-question/readme.md).
 
 ### Start On Time
 
-Make a best effort to begin answering the 3 questions as close to the scheduled start time as possible. Try not to waste time upfront on chit-chat or waiting on all team members to join. This can extend the meeting time significantly. Starting immediately will help ensure stand-ups remain effective and useful over time.
+Make a best effort to begin answering the questions as close to the scheduled start time as possible. Try not to waste time upfront on chit-chat or waiting on all team members to join. This can extend the meeting time significantly. Starting immediately will help ensure stand-ups remain effective and useful over time.
 
 ### Same Time Every weekday
 
@@ -106,13 +106,13 @@ For team members distributed across time zones, consider scheduling the stand-up
 
 ### Contributors Unable to Attend (async updates)
 
-If a contributor knows that they will have to miss the stand-up, ask them to provide their answers to the 3 questions in written form before the stand-up. They could provide these over a shared Teams channel or email to the team. The Process Lead can then read the answers during the stand-up. Reading the update aloud during the stand-up will ensure the answers are communicated to the team.
+If a contributor knows that they will have to miss the stand-up, ask them to provide their answers to the questions in written form before the stand-up. They could provide these over a shared Teams channel or email to the team. The Process Lead can then read the answers during the stand-up. Reading the update aloud during the stand-up will ensure the answers are communicated to the team.
 
 ### Remote Located Team Members
 
-If any team member is working remotely, plan to run stand-ups through conference calls. Ask the team members to keep the camera on as much as possible so that they can see each other when speaking against the 3 questions.
+If any team member is working remotely, plan to run stand-ups through conference calls. Ask the team members to keep the camera on as much as possible so that they can see each other when speaking against the questions.
 
-> **Tip**: In order to keep the remote stand-up as efficient, in a good pace and with the collective sense as it is in a physically located stand-up, you can agree on applying a "pick the next one approach" in which the current contributor to speak picks the next in a loop until everyone with contributions had answered the 3 questions.
+> **Tip**: In order to keep the remote stand-up as efficient, in a good pace and with the collective sense as it is in a physically located stand-up, you can agree on applying a "pick the next one approach" in which the current contributor to speak picks the next in a loop until everyone with contributions had answered the questions.
 
 ## Resources
 

--- a/agile-development/stand-ups/social-question/readme.md
+++ b/agile-development/stand-ups/social-question/readme.md
@@ -1,10 +1,10 @@
 # Social question of the day
 
-The social question of the day is an optional short question to follow the [three project questions](../readme.md) in the daily stand-up. It develops team cohesion and interpersonal trust over the course of an engagement by facilitating the sharing of chosen personal context.
+The social question of the day is an optional short question to follow the [three project questions](../readme.md) in the daily stand-up. It develops team cohesion and interpersonal trust over the course of an engagement by facilitating the sharing of personal preferences, lifestyle, or other context. 
 
-If the team decides to incorporate a social question-of-the-day into the stand-up, the questions can be selected by the facilitator or sourced from the attendees. The latter is faster and the former will likely result in more diverse questions.
+The social question should be chosen before the stand-up. The facilitator should select the question either independently or from the team's asynchronous suggestions. This minimizes delays at the start of the stand-up.
 
-> Tip: having the stand-up facilitator role rotate lets the facilitator choose the social question without burdening any one team member.
+> Tip: having the stand-up facilitator role rotate each sprint lets the facilitator choose the social question independently without burdening any one team member.
 
 ## Properties of a good question
 

--- a/agile-development/stand-ups/social-question/readme.md
+++ b/agile-development/stand-ups/social-question/readme.md
@@ -1,0 +1,39 @@
+# Social question of the day
+
+The social question of the day is an optional short question to follow the [three project questions](../readme.md) in the daily stand-up. It develops team cohesion and interpersonal trust over the course of an engagement by facilitating the sharing of chosen personal context.
+
+If the team decides to incorporate a social question-of-the-day into the stand-up, the questions can be selected by the facilitator or sourced from the attendees. The latter is faster and the former will likely result in more diverse questions.
+
+> Tip: having the stand-up facilitator role rotate lets the facilitator choose the social question without burdening any one team member.
+
+## Properties of a good question
+
+A good question has a brief answer with small optional elaboration. A yes or no answer doesn't tell you very much about someone, while knowing that their favorite fruit is a [durian](https://en.wikipedia.org/wiki/Durian) is informative.
+
+Good questions are low in consequence but allow controversy. Watching someone strongly exclaim that salmon and lox on cinnamon-raisin is the best bagel order is endearing. As a corollary, a good question is one someone is likely to be passionate about. You know a little more about a team member's personality if their eyes light up when describing their favorite karaoke song.
+
+## Starter list of questions
+
+Potentially good questions include:
+
+- What's your Starbucks order?
+- What's your favorite operating system?
+- What's your favorite version of Windows?
+- What's your favorite plant, houseplant or otherwise?
+- What's your favorite fruit?
+- What's your favorite fast food?
+- What's your favorite noodle?
+- What's your favorite text editor?
+- Mountains or beach?
+- DC or Marvel?
+- Coffee with one person from history: who?
+- What's your silliest online purchase?
+- What's your alternate career?
+- What's the best bagel topping?
+- What's your guilty TV pleasure?
+- What's your go-to karaoke song?
+- Would you rather see the past or the future?
+- Would you rather be able to teleport or to fly?
+- Would you rather live underwater or in space for a year?
+- What's your favorite phone app?
+- What's your favorite fish, to eat or otherwise?

--- a/agile-development/stand-ups/social-question/readme.md
+++ b/agile-development/stand-ups/social-question/readme.md
@@ -1,6 +1,6 @@
 # Social question of the day
 
-The social question of the day is an optional short question to follow the [three project questions](../readme.md) in the daily stand-up. It develops team cohesion and interpersonal trust over the course of an engagement by facilitating the sharing of personal preferences, lifestyle, or other context. 
+The social question of the day is an optional short question to follow the [three project questions](../readme.md) in the daily stand-up. It develops team cohesion and interpersonal trust over the course of an engagement by facilitating the sharing of personal preferences, lifestyle, or other context.
 
 The social question should be chosen before the stand-up. The facilitator should select the question either independently or from the team's asynchronous suggestions. This minimizes delays at the start of the stand-up.
 


### PR DESCRIPTION
Describes the purpose and implementation of an optional social question to follow the three project questions during the daily stand-up. Closes #528 . 