### PR TITLE
fix(docs): rephrase main branch in checklist

### DIFF
--- a/ENG-FUNDAMENTALS-CHECKLIST.md
+++ b/ENG-FUNDAMENTALS-CHECKLIST.md
@@ -4,7 +4,7 @@ This checklist helps to ensure that our projects meet our Engineering Fundamenta
 
 ## Source Control
 
-- [ ] The main branch is locked.
+- [ ] The default target branch is locked.
 - [ ] Merges are done through PRs.
 - [ ] PRs reference related work items.
 - [ ] Commit history is consistent and commit messages are informative (what, why).


### PR DESCRIPTION
The main branch is not always the one we're working on in an
engagement, e.g. development is also very common. This fix states clear
that the branch we're working on as a default target is the one that
has to be locked.

Closes: #532