### PR TITLE
remove internal guidance from public contributing.md page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,9 @@ You will still need to submit a PR against master in order to merge your changes
 
 When you have an idea for contribution open an *issue*!
 
-> **Note:** Adding additional details like labels for an issue are only available for the project's Contributors group.
+> **Note:**
+>
+> * Adding additional details like labels for an issue are only available for the project's Contributors group.
 
 ## Git guidance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ You will still need to submit a PR against master in order to merge your changes
 
 When you have an idea for contribution open an *issue*!
 
-> **Note:** * Adding new labels for an issue are only available for the project's Contributors group. Proposals for new labels are welcomed.
+> **Note:** Adding new labels for an issue are only available for the project's Contributors group. Proposals for new labels are welcomed.
 
 ## Git guidance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,7 @@ You will still need to submit a PR against master in order to merge your changes
 
 When you have an idea for contribution open an *issue*!
 
-> **Note:**
->
-> * Adding additional details like labels for an issue are only available for the project's Contributors group.
+> **Note:** * Adding new labels for an issue are only available for the project's Contributors group. Proposals for new labels are welcomed.
 
 ## Git guidance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ You will still need to submit a PR against master in order to merge your changes
 
 When you have an idea for contribution open an *issue*!
 
-More details can be found in the internal CSE Wiki under the page `Contributing_to_the_Code-With_Engineering_Playbook`.
+> **Note:** Adding additional details like labels for an issue are only available for the project's Contributors group.
 
 ## Git guidance
 


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

- A reference to a cse internal wiki page. Removing this reference will make the experience for all readers more uniform.
- #624 

## Description of new changes

- Remove sentence from [#how-to-contribute](https://github.com/microsoft/code-with-engineering-playbook/blob/f36c246aa48750131f75ca1ed6de24cb07f516db/CONTRIBUTING.md#how-to-contribute) section which guides contributors to an internal page.

## For all pull requests

- [x] Link to the issue you are solving (so it gets closed)
- [ ] Label the pull request with the appropriate area(s)
- [ ] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [ ] Assign the project - Engineering Playbook Backlog
- [ ] Assign the pull request to yourself
