### PR TITLE
docs: replaced outdated broken links for multiple docs

### DIFF
--- a/docs/automated-testing/fault-injection-testing/README.md
+++ b/docs/automated-testing/fault-injection-testing/README.md
@@ -55,7 +55,7 @@ Examples of performing fault injection during the development lifecycle:
 
 #### Fault injection testing in the release cycle
 
-Much like [Synthetic Monitoring Tests](../synthetic-monitoring-tests/README.md), fault injection testing in the release cycle is a part of [Shift-Right testing](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/shift-right-test-production) approach, which uses safe methods to perform tests in a production or pre-production environment. Given the nature of distributed, cloud-based applications, it is very difficult to simulate the real behavior of services outside their production environment. Testers are encouraged to run tests where it really matters, on a live system with customer traffic.
+Much like [Synthetic Monitoring Tests](../synthetic-monitoring-tests/README.md), fault injection testing in the release cycle is a part of [Shift-Right testing](https://docs.microsoft.com/en-us/devops/deliver/shift-right-test-production) approach, which uses safe methods to perform tests in a production or pre-production environment. Given the nature of distributed, cloud-based applications, it is very difficult to simulate the real behavior of services outside their production environment. Testers are encouraged to run tests where it really matters, on a live system with customer traffic.
 
 Fault injection tests rely on metrics observability and are usually statistical; The following high-level steps provide a sample of practicing fault injection and chaos engineering:
 

--- a/docs/automated-testing/synthetic-monitoring-tests/README.md
+++ b/docs/automated-testing/synthetic-monitoring-tests/README.md
@@ -94,5 +94,5 @@ When developing a PaaS/SaaS solution, Synthetic monitoring is key to the success
 ## Resources
 
 - [Google SRE book - Testing Reliability](https://landing.google.com/sre/sre-book/chapters/testing-reliability/)
-- [Microsoft DevOps Architectures - Shift Right to Test in Production](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/shift-right-test-production)
+- [Microsoft DevOps Architectures - Shift Right to Test in Production](https://docs.microsoft.com/en-us/devops/deliver/shift-right-test-production)
 - [Martin Fowler - Synthetic Monitoring](https://martinfowler.com/bliki/SyntheticMonitoring.html)

--- a/docs/continuous-integration/README.md
+++ b/docs/continuous-integration/README.md
@@ -146,7 +146,7 @@ An effective way to identify bugs in your build at a rapid pace is to invest ear
   - Prevent commits directly into main branch.
 
 - [ ] **Branch strategy**
-  - Release branches should auto trigger the deployment of a build artifact to its target cloud environment. One branch strategy worth considering is  [trunk-based development](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#manage-releases) and [Release Flow's Branching Structure](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow).
+  - Release branches should auto trigger the deployment of a build artifact to its target cloud environment. One branch strategy worth considering is  [trunk-based development](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#manage-releases) and [Release Flow's Branching Structure](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#port-changes-back-to-the-main-branch).
 
 ## Deliver Quickly and Daily
 

--- a/docs/continuous-integration/README.md
+++ b/docs/continuous-integration/README.md
@@ -146,7 +146,7 @@ An effective way to identify bugs in your build at a rapid pace is to invest ear
   - Prevent commits directly into main branch.
 
 - [ ] **Branch strategy**
-  - Release branches should auto trigger the deployment of a build artifact to its target cloud environment. One branch strategy worth considering is  [trunk-based development](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#manage-releases) and [Release Flow's Branching Structure](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#port-changes-back-to-the-main-branch).
+  - Release branches should auto trigger the deployment of a build artifact to its target cloud environment. One branch strategy worth considering is  [trunk-based development](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#manage-releases) and [Release Flow's Branching Structure](https://docs.microsoft.com/en-us/azure/devops/learn/devops-at-microsoft/release-flow).
 
 ## Deliver Quickly and Daily
 

--- a/docs/observability/tools/OpenTelemetry.md
+++ b/docs/observability/tools/OpenTelemetry.md
@@ -29,7 +29,7 @@ Apart from features like adding custom attributes, sampling, collecting data for
 
 ## Current Status of OpenTelemetry Project
 
-OpenTelemetry is a project which emerged from merging of OpenCensus and OpenTracing in 2019. Although OpenCensus and OpenTracing are frozen and no new features are being developed for them, OpenTelemetry has backward compatibility with OpenCensus and OpenTracing. Some features of OpenTelemetry are still in beta, feature support for different languages is being tracked here: [Feature Status of OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md). Status of OpenTelemetry project can be tracked [here](https://opentelemetry.io/releases/#project-status).
+OpenTelemetry is a project which emerged from merging of OpenCensus and OpenTracing in 2019. Although OpenCensus and OpenTracing are frozen and no new features are being developed for them, OpenTelemetry has backward compatibility with OpenCensus and OpenTracing. Some features of OpenTelemetry are still in beta, feature support for different languages is being tracked here: [Feature Status of OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md). Status of OpenTelemetry project can be tracked [here](https://opentelemetry.io/status/).
 
 ## What to watch out for
 


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

- broken links in the docs of automated-testing and observability
- #644 

## Description of new changes

- Broken links have been replaced with working links that point to the same content

## For all pull requests

- [x] Link to the issue you are solving (so it gets closed)
- [ ] Label the pull request with the appropriate area(s)
- [ ] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [ ] Assign the project - Engineering Playbook Backlog
- [ ] Assign the pull request to yourself
