### PR TITLE
Update .markdownlinkcheck.json

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -8,6 +8,7 @@
         {"pattern": "^http://link-to-story-work-item"},
         {"pattern": "^http://link-to-work-item"},
         {"pattern": "^https://tanzu.vmware.com/developer/guides/kubernetes/observability-prometheus-grafana-p1"},
-        {"pattern": "^https://www.w3.org/blog/2019/12/trace-context-enters-proposed-recommendation/"}
+        {"pattern": "^https://www.w3.org/blog/2019/12/trace-context-enters-proposed-recommendation/"},
+        {"pattern": "^https://blog.cloudflare.com/cloudflare-outage/"}
     ]
 }


### PR DESCRIPTION
# Add link to configuration 

markdown-lin-cheker is returning an 503 error to an working link blocking the PRs

## What are you trying to address

Fix issue with link that is not broken, but the check is not working.

## Description of new changes

add link to `.markdownlinkcheck.json`

## For all pull requests

This PR will close issue #647 
