### PR TITLE
Add Clarity Analytics to MKDocs

### DIFF
--- a/mkdocs-overrides/main.html
+++ b/mkdocs-overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block analytics %}
+<script type="text/javascript">
+  (function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "7gescazz1m");
+</script>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ edit_uri: ""
 
 theme:
   name: material
+  custom_dir: mkdocs-overrides
   font:
     text: Roboto
   palette:


### PR DESCRIPTION
Solving #550

## What are you trying to address

Add analytics to the static website generated with MKDocs using [Microsoft Clarity](https://clarity.microsoft.com/)

## Description of new changes

- Add MKDocs overrides reference to a directory with the html for default html customization.
-  Add an analytics block on the main.html override with the clarity tracking code snippet. 

## For all pull requests

- [ ] Link to the issue you are solving (so it gets closed)
- [ ] Label the pull request with the appropriate area(s)
- [ ] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [ ] Assign the project - Engineering Playbook Backlog
- [ ] Assign the pull request to yourself
