### PR TITLE
Recommend .NET Analyzers over FxCop analyzers for .NET

### DIFF
--- a/docs/code-reviews/recipes/csharp.md
+++ b/docs/code-reviews/recipes/csharp.md
@@ -16,7 +16,7 @@ We recommend using a common setup for your solution that you can refer to in all
 <Project>
 ...
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -47,11 +47,11 @@ The [.editorconfig](https://docs.microsoft.com/en-us/visualstudio/ide/editorconf
 
 [Details about the configuration of different rules](https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019).
 
-### FxCop analyzers
+### .NET analyzers
 
-Microsoft's FxCop analyzers check your code for security, performance, and design issues, among others. [Install FxCop analyzers in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/code-quality/install-fxcop-analyzers?view=vs-2019).
+Microsoft's .NET analyzers has code quality rules and .NET API usage rules implemented as analyzers using the .NET Compiler Platform (Roslyn). This is the replacement for Microsoft's legacy [FxCop analyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/). Starting in Visual Studio 2019 16.8 and .NET 5.0, these analyzers are included with the .NET SDK. It is recommended that you enable the analyzers from the .NET SDK when possible. [Enable or install first-party .NET analyzers](https://docs.microsoft.com/en-us/visualstudio/code-quality/install-net-analyzers?view=vs-2019).
 
-You can install the FxCop analyzers using nuget or a VSIX extension. We recommend using the nuget package ([see Project setup](#project-setup)). Which allows for consistent use across all developers on a project as well as CI validation.
+If you don't want to move to the .NET 5+ SDK or if you prefer a NuGet package-based model, the analyzers are also available in the `Microsoft.CodeAnalysis.NetAnalyzers` [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/).
 
 ### StyleCop analyzer
 

--- a/docs/code-reviews/recipes/csharp.md
+++ b/docs/code-reviews/recipes/csharp.md
@@ -49,9 +49,11 @@ The [.editorconfig](https://docs.microsoft.com/en-us/visualstudio/ide/editorconf
 
 ### .NET analyzers
 
-Microsoft's .NET analyzers has code quality rules and .NET API usage rules implemented as analyzers using the .NET Compiler Platform (Roslyn). This is the replacement for Microsoft's legacy [FxCop analyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/). Starting in Visual Studio 2019 16.8 and .NET 5.0, these analyzers are included with the .NET SDK. It is recommended that you enable the analyzers from the .NET SDK when possible. [Enable or install first-party .NET analyzers](https://docs.microsoft.com/en-us/visualstudio/code-quality/install-net-analyzers?view=vs-2019).
+Microsoft's .NET analyzers has code quality rules and .NET API usage rules implemented as analyzers using the .NET Compiler Platform (Roslyn). This is the replacement for Microsoft's legacy [FxCop analyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/).
 
-If you don't want to move to the .NET 5+ SDK or if you prefer a NuGet package-based model, the analyzers are also available in the `Microsoft.CodeAnalysis.NetAnalyzers` [NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/).
+[Enable or install first-party .NET analyzers](https://docs.microsoft.com/en-us/visualstudio/code-quality/install-net-analyzers?view=vs-2019).
+
+If you are currently using the legacy FxCop analyzers, [migrate from FxCop analyzers to .NET analyzers](https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019).
 
 ### StyleCop analyzer
 


### PR DESCRIPTION
# Recommend .NET Analyzers over FxCop analyzers for .NET

## What are you trying to address

C# code analysis project setup is currently referring to FxCop which is retired. The replacement is .NET Analyzers which is included with the .NET SDK starting in Visual Studio 2019 16.8 and .NET 5.0. And, available as a Nuget package for older projects.

Closes #705 

## Description of new changes

- Replace FxCop analyzers section with .NET analyzers.
- Update the sample to use .NET analyzers.

## For all pull requests

- [x] Link to the issue you are solving (so it gets closed)
- [x] Label the pull request with the appropriate area(s)
- [x] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [x] Assign the project - Engineering Playbook Backlog
- [x] Assign the pull request to yourself
