### PR TITLE
Add MKDocs recipe to Documentation section

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -77,7 +77,7 @@ When working in an engineering project, we typically encounter one or more of th
 ## Recipes
 
 - [How to sync a wiki between repositories](./recipes/sync-wiki-between-repos.md)
-- [How to create a static website for your documentation based on mkdocs and mkdocs-material](./recipes/static-website-with-mkdocs.md)
+- [How to create a static website for your documentation based on MkDocs and Material for MkDocs](./recipes/static-website-with-mkdocs.md)
 
 ## Resources
 

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -77,6 +77,7 @@ When working in an engineering project, we typically encounter one or more of th
 ## Recipes
 
 - [How to sync a wiki between repositories](./recipes/sync-wiki-between-repos.md)
+- [How to create a static website for your documentation based on mkdocs and mkdocs-material](./recipes/static-website-with-mkdocs.md)
 
 ## Resources
 

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -26,3 +26,8 @@ To setup an MKDocs website, the main assets needed are:
 Setting up locally is very easy. See [Getting Started with MkDocs](https://www.mkdocs.org/getting-started/) for details.
 
 For publishing the website, there's a [good integration with Github for storing the website as a Github Page](https://www.mkdocs.org/user-guide/deploying-your-docs/).
+
+## Additional links
+
+- [MkDocs Plugins](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins)
+- [The best MkDocs plugins and customizations](https://chrieke.medium.com/the-best-mkdocs-plugins-and-customizations-fc820eb19759)

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -1,25 +1,28 @@
 # How to create a static website for your documentation based on mkdocs and mkdocs-material
 
-MKDocs is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/) and [Jekyll](https://jekyllrb.com/). 
+[MKDocs](https://www.mkdocs.org/) is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/), and [Jekyll](https://jekyllrb.com/).
+
+We used MKDocs to create [CSE Code-With Engineering Playbook](https://microsoft.github.io/code-with-engineering-playbook/) static website from the contents in [microsoft / code-with-engineering-playbook](https://github.com/microsoft/code-with-engineering-playbook) GitHub repository. Then we deployed it to a [GitHub Page](https://pages.github.com/).
 
 We found MKDocs to be a good choice since:
 
 1. It's easy to set up and looks great even with the vanilla version.
-2. It works well with markdown, which is what we already have in the playbook.
-3. It uses a Python stack which is friendly to many contributors of this playbook.
+2. It works well with markdown, which is what we already have in the Playbook.
+3. It uses a Python stack which is friendly to many contributors of this Playbook.
 
 For comparison, Sphinx mainly generates docs from restructured-text (rst) format, and Jekyll is written in Ruby.
 
-To setup an mkdocs website, the main assets needed are:
+To setup an MKDocs website, the main assets needed are:
 
-1. An ```mkdocs.yaml``` file, similar to the one we have [in our repo](https://github.com/microsoft/code-with-engineering-playbook/blob/main/mkdocs.yml). This is the configuration file that defines the appearance of the website, the navigation, the plugins used and more.
-2. A Github action for automatically generating the website (e.g. on every commit to main), similar to [this one from our repo](https://github.com/microsoft/code-with-engineering-playbook/blob/main/.github/workflows/mkdocs.yml).
-3. A list of plugins used during the build phase of the website. We specified ours [here](https://github.com/microsoft/code-with-engineering-playbook/blob/main/requirements-docs.txt).
+1. An ```mkdocs.yaml``` file, similar to the one we have [in the Playbook](https://github.com/microsoft/code-with-engineering-playbook/blob/main/mkdocs.yml). This is the configuration file that defines the appearance of the website, the navigation, the plugins used and more.
+2. A folder named ```docs``` (the default value for the directory) that contains the documentation source files.
+3. A [Github Action](https://docs.github.com/actions/learn-github-actions/understanding-github-actions) for automatically generating the website (e.g. on every commit to main), similar to [this one from the Playbook](https://github.com/microsoft/code-with-engineering-playbook/blob/main/.github/workflows/mkdocs.yml).
+4. A list of plugins used during the build phase of the website. We specified ours [here](https://github.com/microsoft/code-with-engineering-playbook/blob/main/requirements-docs.txt). And these are the plugins we've used:
 
-Setting up locally is also very easy (see some documentation [here](https://www.mkdocs.org/getting-started/)). For publishing the website, there's a [good integration with Github for storing the website as a Github Page](https://www.mkdocs.org/user-guide/deploying-your-docs/).
+    - [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/): Material design appearance and user experience.
+    - [pymdown-extensions](https://facelessuser.github.io/pymdown-extensions/): Improves the appearance of markdown based content.
+    - [mdx_truly_sane_lists](https://github.com/radude/mdx_truly_sane_lists): For defining the indent level for lists without having to refactor the entire documentation we already had in the Playbook.
 
-The plugins we've used:
+Setting up locally is very easy. See [Getting Started with MkDocs](https://www.mkdocs.org/getting-started/) for details.
 
-- [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/): Material design appearance and user experience.
-- [pymdown-extensions](https://facelessuser.github.io/pymdown-extensions/): Improves the appearance of markdown based content.
-- [mdx_truly_sane_lists](https://github.com/radude/mdx_truly_sane_lists): For defining the indent level for lists without having to refactor the entire documentation we already had in the playbook.
+For publishing the website, there's a [good integration with Github for storing the website as a Github Page](https://www.mkdocs.org/user-guide/deploying-your-docs/).

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -1,6 +1,6 @@
 # How to create a static website for your documentation based on mkdocs and mkdocs-material
 
-[MKDocs](https://www.mkdocs.org/) is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/), and [Jekyll](https://jekyllrb.com/).
+[MkDocs](https://www.mkdocs.org/) is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/), and [Jekyll](https://jekyllrb.com/).
 
 We used MKDocs to create [CSE Code-With Engineering Playbook](https://microsoft.github.io/code-with-engineering-playbook/) static website from the contents in [microsoft / code-with-engineering-playbook](https://github.com/microsoft/code-with-engineering-playbook) GitHub repository. Then we deployed it to a [GitHub Page](https://pages.github.com/).
 

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -2,7 +2,7 @@
 
 [MkDocs](https://www.mkdocs.org/) is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/), and [Jekyll](https://jekyllrb.com/).
 
-We used MKDocs to create [CSE Code-With Engineering Playbook](https://microsoft.github.io/code-with-engineering-playbook/) static website from the contents in [microsoft / code-with-engineering-playbook](https://github.com/microsoft/code-with-engineering-playbook) GitHub repository. Then we deployed it to a [GitHub Page](https://pages.github.com/).
+We used MkDocs to create [CSE Code-With Engineering Playbook](https://microsoft.github.io/code-with-engineering-playbook/) static website from the contents in [the GitHub repository](https://github.com/microsoft/code-with-engineering-playbook). Then we deployed it to [GitHub Pages](https://pages.github.com/).
 
 We found MkDocs to be a good choice since:
 

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -4,7 +4,7 @@
 
 We used MKDocs to create [CSE Code-With Engineering Playbook](https://microsoft.github.io/code-with-engineering-playbook/) static website from the contents in [microsoft / code-with-engineering-playbook](https://github.com/microsoft/code-with-engineering-playbook) GitHub repository. Then we deployed it to a [GitHub Page](https://pages.github.com/).
 
-We found MKDocs to be a good choice since:
+We found MkDocs to be a good choice since:
 
 1. It's easy to set up and looks great even with the vanilla version.
 2. It works well with markdown, which is what we already have in the Playbook.

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -1,0 +1,25 @@
+# How to create a static website for your documentation based on mkdocs and mkdocs-material
+
+MKDocs is a tool built to create static websites from raw markdown files. Other alternatives include [Sphinx](https://www.sphinx-doc.org/en/master/) and [Jekyll](https://jekyllrb.com/). 
+
+We found MKDocs to be a good choice since:
+
+1. It's easy to set up and looks great even with the vanilla version.
+2. It works well with markdown, which is what we already have in the playbook.
+3. It uses a Python stack which is friendly to many contributors of this playbook.
+
+For comparison, Sphinx mainly generates docs from restructured-text (rst) format, and Jekyll is written in Ruby.
+
+To setup an mkdocs website, the main assets needed are:
+
+1. An ```mkdocs.yaml``` file, similar to the one we have [in our repo](https://github.com/microsoft/code-with-engineering-playbook/blob/main/mkdocs.yml). This is the configuration file that defines the appearance of the website, the navigation, the plugins used and more.
+2. A Github action for automatically generating the website (e.g. on every commit to main), similar to [this one from our repo](https://github.com/microsoft/code-with-engineering-playbook/blob/main/.github/workflows/mkdocs.yml).
+3. A list of plugins used during the build phase of the website. We specified ours [here](https://github.com/microsoft/code-with-engineering-playbook/blob/main/requirements-docs.txt).
+
+Setting up locally is also very easy (see some documentation [here](https://www.mkdocs.org/getting-started/)). For publishing the website, there's a [good integration with Github for storing the website as a Github Page](https://www.mkdocs.org/user-guide/deploying-your-docs/).
+
+The plugins we've used:
+
+- [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/): Material design appearance and user experience.
+- [pymdown-extensions](https://facelessuser.github.io/pymdown-extensions/): Improves the appearance of markdown based content.
+- [mdx_truly_sane_lists](https://github.com/radude/mdx_truly_sane_lists): For defining the indent level for lists without having to refactor the entire documentation we already had in the playbook.

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -19,7 +19,7 @@ To setup an MKDocs website, the main assets needed are:
 3. A [Github Action](https://docs.github.com/actions/learn-github-actions/understanding-github-actions) for automatically generating the website (e.g. on every commit to main), similar to [this one from the Playbook](https://github.com/microsoft/code-with-engineering-playbook/blob/main/.github/workflows/mkdocs.yml).
 4. A list of plugins used during the build phase of the website. We specified ours [here](https://github.com/microsoft/code-with-engineering-playbook/blob/main/requirements-docs.txt). And these are the plugins we've used:
 
-    - [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/): Material design appearance and user experience.
+    - [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/): Material design appearance and user experience.
     - [pymdown-extensions](https://facelessuser.github.io/pymdown-extensions/): Improves the appearance of markdown based content.
     - [mdx_truly_sane_lists](https://github.com/radude/mdx_truly_sane_lists): For defining the indent level for lists without having to refactor the entire documentation we already had in the Playbook.
 

--- a/docs/documentation/recipes/static-website-with-mkdocs.md
+++ b/docs/documentation/recipes/static-website-with-mkdocs.md
@@ -12,7 +12,7 @@ We found MkDocs to be a good choice since:
 
 For comparison, Sphinx mainly generates docs from restructured-text (rst) format, and Jekyll is written in Ruby.
 
-To setup an MKDocs website, the main assets needed are:
+To setup an MkDocs website, the main assets needed are:
 
 1. An ```mkdocs.yaml``` file, similar to the one we have [in the Playbook](https://github.com/microsoft/code-with-engineering-playbook/blob/main/mkdocs.yml). This is the configuration file that defines the appearance of the website, the navigation, the plugins used and more.
 2. A folder named ```docs``` (the default value for the directory) that contains the documentation source files.


### PR DESCRIPTION
## What are you trying to address

Add a new "How to create a static website for your documentation based on mkdocs and mkdocs-material" document under Recipes in documentation/recipes.

Closes #689.

## For all pull requests

- [X] Link to the issue you are solving (so it gets closed)
- [X] Label the pull request with the appropriate area(s)
- [X] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [X] Assign the project - Engineering Playbook Backlog
- [X] Assign the pull request to yourself
