### PR TITLE
move decision-logs examples back into the design tree

### DIFF
--- a/docs/design/design-reviews/decision-log/examples/memory/Architecture/Data-Model.md
+++ b/docs/design/design-reviews/decision-log/examples/memory/Architecture/Data-Model.md
@@ -2,10 +2,10 @@
 
 ## Table of Contents
 
-- [Graph vertices and edges](#Graph-vertices-and-Edges)
-- [Graph Properties](#Graph-Properties)
-- [Vertex Descriptions](#Vertex-Descriptions)
-- [Full Role JSON Example](#Full-Role-JSON-Example)
+- [Graph vertices and edges](#graph-vertices-and-edges)
+- [Graph Properties](#graph-properties)
+- [Vertex Descriptions](#vertex-descriptions)
+- [Full Role JSON Example](#full-role-json-example)
 
 ## Graph Model
 
@@ -93,7 +93,7 @@ Top most level of categorization
 {
     "title": "Software Engineering",
     "description": "Description of profession",
-    "disciplines: []
+    "disciplines": []
 }
 ```
 
@@ -166,7 +166,7 @@ The way in which one acts or conducts oneself
 
 ### User
 
-The user object refers to who a person is.
+The user object refers to whom a person is.
 We do not store our own rather use Azure OIDs.
 
 ### User Profile
@@ -179,9 +179,9 @@ A user may hold multiple personas.
 
 ### Entry
 
-The same entry object can hold many different kinds of data, and at this stage of the project we decide that we will not store external data, so it's up to the user to provide a link to the data for a reader to click into and get redirected to a new tab to open.
+The same entry object can hold many kinds of data, and at this stage of the project we decide that we will not store external data, so it's up to the user to provide a link to the data for a reader to click into and get redirected to a new tab to open.
 
-> Note: This means that in the web app, we will need to ensure links are opened in new tabs.
+> **Note:** This means that in the web app, we will need to ensure links are opened in new tabs.
 
 ### Project
 

--- a/docs/design/design-reviews/decision-log/examples/memory/Decision-Log.md
+++ b/docs/design/design-reviews/decision-log/examples/memory/Decision-Log.md
@@ -6,7 +6,7 @@ This can be used at a later stage to understand why decisions were made and by w
 | **Decision** | **Date** | **Alternatives Considered** | **Reasoning** | **Detailed doc** | **Made By** | **Work Required** |
 | --- | --- |  --- | --- | --- | --- | --- |
 | Use Architecture Decision Records | 01/25/2021 | Standard Design Docs | An easy and low cost solution of tracking architecture decisions over the lifetime of a project | Record Architecture Decisions | Dev Team | #21654 |
-| Use ArgoCD | 01/26/2021 | FluxCD | ArgoCD is more feature rich, will support more scenarios, and will be a better tool to put in our tool belts. So we have decided at this point to go with ArgoCD | [GitOps Trade Study](./Trade-Studies/GitOps.md) | Dev Team | #21672 |
+| Use ArgoCD | 01/26/2021 | FluxCD | ArgoCD is more feature rich, will support more scenarios, and will be a better tool to put in our tool belts. So we have decided at this point to go with ArgoCD | [GitOps Trade Study](Trade-Studies/GitOps.md) | Dev Team | #21672 |
 | Use Helm | 01/28/2021 | Kustomize, Kubes, Gitkube, Draft | Platform maturity, templating, ArgoCD support | K8s Package Manager Trade Study | Dev Team | #21674 |
 | Use CosmosDB | 01/29/2021 | Blob Storage, CosmosDB, SQL Server, Neo4j, JanusGraph, ArangoDB | CosmosDB has better Azure integration, managed identity, and the Gremlin API is powerful. | Graph Storage Trade Study and Decision | Dev Team | #21650 |
 | Use Azure Traffic Manager | 02/02/2021 | Azure Front Door | A lightweight solution to route traffic between multiple k8s regional clusters | Routing Trade Study | Dev Team | #21673

--- a/docs/design/design-reviews/decision-log/examples/memory/Deployment/Environments.md
+++ b/docs/design/design-reviews/decision-log/examples/memory/Deployment/Environments.md
@@ -10,8 +10,8 @@ The Memory project uses multiple environments to isolate and test changes before
 
 New environment rollouts are automatically triggered based upon a successful deployment of the previous stage /environment.
 
-The **development**, **staging** and **production** environments leverage slot deployment during a environment rollout.
-After a new release is deployed to a staging slot it is validated through a series of functional integration tests.
+The **development**, **staging** and **production** environments leverage slot deployment during an environment rollout.
+After a new release is deployed to a staging slot, it is validated through a series of functional integration tests.
 Upon a 100% pass rate of all tests the staging & production slots are swapped effectively making updates to the environment available.
 
 Any errors or failed tests halt the deployment in the current stage and prevent changes to further environments.
@@ -50,7 +50,7 @@ All code that is checked into the `main` branch is automatically deployed to thi
 ### Staging
 
 The staging environment is used to validate new features, components and other changes prior to production rollout.
-This environment is primarily used by developers, QA and other company stake holders.
+This environment is primarily used by developers, QA and other company stakeholders.
 
 #### Staging Regions
 

--- a/docs/design/design-reviews/decision-log/examples/memory/README.md
+++ b/docs/design/design-reviews/decision-log/examples/memory/README.md
@@ -2,6 +2,6 @@
 
 These examples were taken from the Memory project, an internal tool for tracking an individual's accomplishments.
 
-The main example here is the [Decision Log](./Decision-Log.md).
+The main example here is the [Decision Log](Decision-Log.md).
 Since this log was used from the start, the decisions are mostly based on technology choices made in the start of the project.
 All line items have a link out to the trade studies done for each technology choice.

--- a/docs/design/design-reviews/decision-log/examples/memory/Trade-Studies/GitOps.md
+++ b/docs/design/design-reviews/decision-log/examples/memory/Trade-Studies/GitOps.md
@@ -54,7 +54,7 @@ The other does the same, with additional features that may or may not be worth t
    - [v2 is published under Apache license in GitHub](https://github.com/fluxcd/flux2), it works with Helm v3, and has PR commits from as recently as today
    - 945 stars, 94 forks
 1. User Interface
-   - CLI, simplest lightweight option
+   - CLI, the simplest lightweight option
 
 Other features to call out (see more on website)
 
@@ -107,7 +107,7 @@ ArgoCD is a declarative, GitOps-based Continuous Delivery (CD) tool for Kubernet
      [RBAC](https://argoproj.github.io/argo-cd/operator-manual/rbac/) requires SSO configuration or one or more local users setup.
      Once SSO or local users are configured, additional RBAC roles can be defined
    - Argo CD does not have its own user management system and has only one built-in user admin.
-     The admin user is a superuser and it has unrestricted access to the system
+     The admin user is a superuser, and it has unrestricted access to the system
    - [Authorization is handled via JWT tokens](https://argoproj.github.io/argo-cd/operator-manual/security/#authentication) and checking group claims in them
 1. Azure Documentation availability
    - Argo has [documentation](https://argoproj.github.io/argo-cd/operator-manual/user-management/microsoft/) on Azure AD
@@ -122,7 +122,7 @@ ArgoCD is a declarative, GitOps-based Continuous Delivery (CD) tool for Kubernet
 Other features to call out (see more on website)
 
 - ArgoCD support both pull model and push model for continuous delivery
-- Argo can send notifications but you need a separate tool for it
+- Argo can send notifications, but you need a separate tool for it
 - Argo can receive webhooks
 - Health assessments
 - Potentially much more useful multi-tenancy tools.


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

The design reviews folder has moved under design, but when merging an old PR, some design review content was accidentally left in the root. This moves it to the right location
