### PR TITLE
Adding auto assigning of reviewers based on engineering fundamental

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -22,7 +22,7 @@ reviewers:
     design: 
       - zmmille2
     dev-experience:
-      - xxxx
+      - olasowemimo
     div-inclusion:
       - madossan01
     documentation: 

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -13,7 +13,7 @@ reviewers:
       - omri374
     automated-testing:
       - alkofahi
-      - omri374
+      - omusavi
     code-reviews:
       - katyamust
       - TessFerrandez
@@ -27,14 +27,20 @@ reviewers:
       - madossan01
     documentation: 
       - magencio
+      - tompaana
+      - TessFerrandez
     machine-learning:
       - biancafbmd
+      - omri374
+      - TessFerrandez
     observability:
       - NarmathaBala
     privacy: 
       - prnata
+      - omri374
     source-code:
       - TessFerrandez
+      - tompaana
 
 files:
   # Keys are glob expressions.

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,74 @@
+reviewers:
+  # The default reviewers
+  defaults:
+    - repository-owners # group
+
+  # Reviewer groups each of which has a list of GitHub usernames
+  groups:
+    repository-owners:
+      - wbreza
+      - fnocera
+    agile:
+      - meulta
+      - omri374
+    automated-testing:
+      - alkofahi
+      - omri374
+    code-reviews:
+      - katyamust
+      - TessFerrandez
+    ci-cd:
+      - brockneedscoffee
+    design: 
+      - zmmille2
+    dev-experience:
+      - xxxx
+    div-inclusion:
+      - madossan01
+    documentation: 
+      - magencio
+    machine-learning:
+      - biancafbmd
+    observability:
+      - NarmathaBala
+    privacy: 
+      - prnata
+    source-code:
+      - TessFerrandez
+
+files:
+  # Keys are glob expressions.
+  # You can assign groups defined above as well as GitHub usernames.
+  'docs/agile-development/**':
+    - agile # group
+  'docs/automated-testing/**':
+    - automated-testing # group
+  'docs/code-reviews/**':
+    - code-reviews # group
+  'docs/continuous-delivery/**':
+    - ci-cd # group
+  'docs/continuous-integration/**':
+    - ci-cd # group
+  'docs/design/**':
+    - design # group
+  'docs/developer-experience/**':
+    - dev-experience # group
+  'docs/documentation/**':
+    - documentation # group
+  'docs/machine-learning/**':
+    - machine-learning # group
+  'docs/observability/**':
+    - observability # group
+  'docs/privacy/**':
+    - privacy # group
+  'docs/source-control/**':
+    - source-code # group
+  '.projector/**':
+    - design # group
+    - wbreza  # username
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - DO NOT REVIEW
+  enable_group_assignment: false

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

- Adding a default list of reviewers by directory folder structure which corresponds to fundamental area so that reviewers get automatically assigned to new PRs
- Addresses part of #675 but not the whole issue

**Am looking for input and feedback on the names for each section: ideally we could add everyone in each fundamental area so that everyone in each area gets tagged on each relevant PR, as well as any other suggestions on rules**
 
## Description of new changes

- Adding a new github action workflow `.github/workflows/auto_request_review.yml` 
- Adding a new configuration yml with reviewers `.github/reviewers.yml`

## For all pull requests

- [x] Link to the issue you are solving (so it gets closed)
- [x] Label the pull request with the appropriate area(s)
- [x] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [x] Assign the project - Engineering Playbook Backlog
- [x] Assign the pull request to yourself
