### PR TITLE
Create stale issues flow

### DIFF
--- a/.github/workflows/stale_issues_flow
+++ b/.github/workflows/stale_issues_flow
@@ -16,7 +16,7 @@ jobs:
           days-before-issue-stale: 90
           days-before-issue-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity."
+          stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity. Please comment on the issue to re-activate it, if it is still relevant."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/stale_issues_flow
+++ b/.github/workflows/stale_issues_flow
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           days-before-issue-stale: 90
-          days-before-issue-close: 14
+          days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity. If not active, it will be closed in 14 days."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."

--- a/.github/workflows/stale_issues_flow
+++ b/.github/workflows/stale_issues_flow
@@ -1,0 +1,23 @@
+name: Close inactive issues
+# At 00:00 on every day-of-week from Monday through Friday.
+on:
+  schedule:
+    - cron: "0 0 * * 1-5"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity. If not active, it will be closed in 14 days."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_issues_flow
+++ b/.github/workflows/stale_issues_flow
@@ -16,7 +16,7 @@ jobs:
           days-before-issue-stale: 90
           days-before-issue-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity. If not active, it will be closed in 14 days."
+          stale-issue-message: "This issue is stale because it has been open for over 90 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
## What are you trying to address

Our issues backlog is field with stale issues.
Give 90 days for an issue to be solved, when not solved, put a notification and when that doesn't work close it after 14 days.
#839 

## Description of new changes

Using github workflow to solve the issue

## For all pull requests

- [ ] Link to the issue you are solving (so it gets closed)
- [ ] Label the pull request with the appropriate area(s)
- [ ] Assign potential reviewers (you may also want to contact them on Teams to ensure timely reviews)
- [ ] Assign the project - Engineering Playbook Backlog
- [ ] Assign the pull request to yourself
