### PR TITLE
Update MegaLinter job config to have reports as artifacts

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: MegaLinter reports
           path: |
-            report
+            megalinter-reports
             mega-linter.log
 
       # Create pull request if applicable (for now works only on PR from same repository, not from forks)


### PR DESCRIPTION
all is in the title :)

It will allow to to see reports as build artifacts

https://oxsecurity.github.io/megalinter/latest/reporters/TextReporter/#get-artifacts-on-github-actions