### PR TITLE
Make sure pipeline won't fail on reviewers request -> permissions iss…

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -16,3 +16,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/reviewers.yml # Config file location override
+        continue-on-error: true
+      - name: Exit properly
+        run: exit 0


### PR DESCRIPTION
Make sure we won't fail the pipeline over review request.
Failing due to permissions in GitHub over the repository when doing PRs from external repos.
