### PR TITLE
docs(secret-management): remove duplicate info, update note, and update link

### DIFF
--- a/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
+++ b/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
@@ -94,7 +94,6 @@ Disadvantages:
 - The [Kubernetes Secret containing the service principal credentials](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/) need to be created as a secret in the same namespace as the application pod. If pods in multiple namespaces need to use the same SP to access Key Vault, this Kubernetes Secret needs to be created in each namespace.
 - The GitOps repo must contain the name of the Key Vault within the SecretProviderClass
 - Must mount secrets as volumes to allow syncing into Kubernetes Secrets
-- [Missing disconnected scenario support](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/446): When the node is offline the SSCSID fails to fetch the secret and thus mounting the volume fails, making scaling and restarting pods not possible while being offline
 - Uses more resources (4 pods; CSI Storage driver and provider) and is a daemonset - not test on RPS / resource usage
 
 ### [External Secrets Operator with Azure Key Vault](https://external-secrets.io/)

--- a/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
+++ b/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
@@ -100,7 +100,7 @@ Disadvantages:
 
 The External Secrets Operator (ESO) is an open-sourced Kubernetes operator that can read secrets from external secret stores (e.g., Azure Key Vault) and sync those into Kubernetes Secrets. In contrast to the CSI Driver, the ESO controller creates the secrets on the cluster as K8s secrets, instead of mounting them as volumes to pods.
 
-Docs on using ESO Azure Key vault provider [here](https://external-secrets.io/v0.4.4/provider-azure-key-vault/).
+Docs on using ESO Azure Key vault provider [here](https://external-secrets.io/v0.8.1/provider/azure-key-vault/).
 
 ESO will need access to Azure Key Vault either through the use of a service principal or managed identity (via [Azure AD Workload Identity](https://github.com/Azure/azure-workload-identity)(recommended) or [AAD Pod Identity](https://github.com/Azure/aad-pod-identity)).
 

--- a/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
+++ b/docs/continuous-delivery/gitops/secret-management/secret-management-gitops.md
@@ -102,6 +102,8 @@ The External Secrets Operator (ESO) is an open-sourced Kubernetes operator that 
 
 Docs on using ESO Azure Key vault provider [here](https://external-secrets.io/v0.4.4/provider-azure-key-vault/).
 
+ESO will need access to Azure Key Vault either through the use of a service principal or managed identity (via [Azure AD Workload Identity](https://github.com/Azure/azure-workload-identity)(recommended) or [AAD Pod Identity](https://github.com/Azure/aad-pod-identity)).
+
 Advantages:
 
 - Supports auto rotation of secrets with customizable sync intervals per **secret**.


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

While reviewing the document I noticed there was a duplicate bullet point in one of the sections. 

Also, while reading the Secret Store CSI Driver (SSCSID) section, specifically around needing to use a service principal/managed identity to access Key Vault, I was (wrongfully) lead to believe External Secret Operator (ESO) did not have the same requirement. I've updated ESO's section, noting you do indeed need to use a sp/mi to access kv.

The link to ESO's Azure Key Vault provider was out-of-date. I've updated the link to a more recent update.
