### PR TITLE
Adding TypeSpec references

### DIFF
--- a/docs/design/design-patterns/rest-api-design-guidance/README.md
+++ b/docs/design/design-patterns/rest-api-design-guidance/README.md
@@ -86,7 +86,9 @@ In particular, when working in an existing API ecosystem, be sure to align with 
 ## Additional Resources
 
 * [Microsoft's Recommended Reading List for REST APIs](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#31-recommended-reading)
+* [Documentation - Guidance - REST APIs](https://microsoft.github.io/code-with-engineering-playbook/documentation/guidance/rest-apis/)
 * [Detailed HTTP status code definitions](https://www.restapitutorial.com/httpstatuscodes.html)
 * [Semantic Versioning](https://semver.org/)
 * [Other Public API Guidelines](http://apistylebook.com/design/guidelines/)
 * [OpenAPI Design Practices](https://oai.github.io/Documentation/best-practices.html)
+* [Microsoft TypeSpec](https://github.com/Microsoft/typespec)

--- a/docs/design/design-patterns/rest-api-design-guidance/README.md
+++ b/docs/design/design-patterns/rest-api-design-guidance/README.md
@@ -56,6 +56,7 @@ Important Points to consider:
 
 * If API requirements changes often during initial development phase, than a Design-First approach may not be a good fit as this will introduce additional overhead, requiring repeated updates & maintenance to the API contract definitions.
 * It might be worthwhile to first try out your platform specific code generator and evaluate how much more additional work will be required in order to meet your project requirements and coding guidelines because it is possible that a particular platform specific code generator might not be able to generate a flexible & maintainable implementation of actual code. For instance If your web framework requires annotations to be present on your controller classes (e.g. for API versioning or authentication), make sure that the code generation tool you use fully supports them.
+* [Microsoft TypeSpec](https://github.com/Microsoft/typespec) is a valuable tool for developers who are working on complex APIs. By providing reusable patterns it can streamline API development and promote best practices. We have put together some [samples about how to enforce an API design-first approach in a GitHub CI/CD pipeline](https://github.com/cse-labs/typespec-workflow-samples/) to help accelerate it's addoption in a Design-First Development.
 
 ### Code-First Approach
 
@@ -92,3 +93,4 @@ In particular, when working in an existing API ecosystem, be sure to align with 
 * [Other Public API Guidelines](http://apistylebook.com/design/guidelines/)
 * [OpenAPI Design Practices](https://oai.github.io/Documentation/best-practices.html)
 * [Microsoft TypeSpec](https://github.com/Microsoft/typespec)
+* [Microsoft TypeSpec GitHub Workflow samples](https://github.com/cse-labs/typespec-workflow-samples/) 

--- a/docs/documentation/guidance/rest-apis.md
+++ b/docs/documentation/guidance/rest-apis.md
@@ -10,11 +10,11 @@ There are implementations available for many languages like C#, including low-le
 
 ## Using Microsoft TypeSpec
 
-While the OpenAPI Specification (OAS) is a popular method for defining and documenting RESTful APIs, there are other languages available that can simplify and expedite the documentation process. Microsoft TypeSpec is one such language that allows for the description of cloud service APIs and the generation of API description languages, client and service code, documentation, and other assets.
+While the [OpenAPI-Specification (OAI)](https://github.com/OAI/OpenAPI-Specification/) is a popular method for defining and documenting RESTful APIs, there are other languages available that can simplify and expedite the documentation process. Microsoft TypeSpec is one such language that allows for the description of cloud service APIs and the generation of API description languages, client and service code, documentation, and other assets.
 
-TypeSpec is a highly extensible language that offers a set of core primitives that can describe API shapes common among REST, OpenAPI, GraphQL, gRPC, and other protocols. This makes it a versatile option for developers who need to work with a range of different API styles and technologies.
+[Microsoft TypeSpec](https://github.com/Microsoft/typespec) is a highly extensible language that offers a set of core primitives that can describe API shapes common among REST, OpenAPI, GraphQL, gRPC, and other protocols. This makes it a versatile option for developers who need to work with a range of different API styles and technologies.
 
-TypeSpec is a widely adopted tool within Azure teams, particularly for generating OpenAPI Specifications in complex and interconnected APIs that span multiple teams. To ensure consistency across different parts of the API, teams commonly leverage shared libraries which contain reusable patterns. This makes easier to follow best practices rather than deviating from them. By promoting highly regular API designs that adhere to best practices by construction, TypeSpec can help improve the quality and consistency of APIs developed within an organization.
+[Microsoft TypeSpec](https://github.com/Microsoft/typespec) is a widely adopted tool within Azure teams, particularly for generating OpenAPI Specifications in complex and interconnected APIs that span multiple teams. To ensure consistency across different parts of the API, teams commonly leverage shared libraries which contain reusable patterns. This makes easier to follow best practices rather than deviating from them. By promoting highly regular API designs that adhere to best practices by construction, TypeSpec can help improve the quality and consistency of APIs developed within an organization.
 
 ## References
 

--- a/docs/documentation/guidance/rest-apis.md
+++ b/docs/documentation/guidance/rest-apis.md
@@ -8,6 +8,16 @@ When creating [REST APIs](https://en.wikipedia.org/wiki/Representational_state_t
 
 There are implementations available for many languages like C#, including low-level tooling, editors, user interfaces, code generators, etc. Here you can find a list of known tooling for the different languages: [OpenAPI-Specification/IMPLEMENTATIONS.md](https://github.com/OAI/OpenAPI-Specification/blob/main/IMPLEMENTATIONS.md).
 
-More information:
+## Using Microsoft TypeSpec
+
+While the OpenAPI Specification (OAS) is a popular method for defining and documenting RESTful APIs, there are other languages available that can simplify and expedite the documentation process. Microsoft TypeSpec is one such language that allows for the description of cloud service APIs and the generation of API description languages, client and service code, documentation, and other assets.
+
+TypeSpec is a highly extensible language that offers a set of core primitives that can describe API shapes common among REST, OpenAPI, GraphQL, gRPC, and other protocols. This makes it a versatile option for developers who need to work with a range of different API styles and technologies.
+
+TypeSpec is a widely adopted tool within Azure teams, particularly for generating OpenAPI Specifications in complex and interconnected APIs that span multiple teams. To ensure consistency across different parts of the API, teams commonly leverage shared libraries which contain reusable patterns. This makes easier to follow best practices rather than deviating from them. By promoting highly regular API designs that adhere to best practices by construction, TypeSpec can help improve the quality and consistency of APIs developed within an organization.
+
+## References
 
 - [ASP.NET Core web API documentation with Swagger / OpenAPI](https://learn.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger?view=aspnetcore-5.0).
+- [Microsoft TypeSpec](https://github.com/Microsoft/typespec).
+- [Design Patterns - REST API Guidance](https://microsoft.github.io/code-with-engineering-playbook/design/design-patterns/rest-api-design-guidance/)


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

In our last project we struggled to implement API design first until we leveraged into Microsoft TypeSpec, which is widely used in Azure PGs. I think adding references and information about TypeSpec would greatly improve the content about REST API references.

I am also adding cross references between design and documentation which seems is missing here.