### PR TITLE
Typo, and missing line in docker-compose sample

### DIFF
--- a/docs/developer-experience/going-further.md
+++ b/docs/developer-experience/going-further.md
@@ -73,7 +73,7 @@ services:
     command: sleep infinity
 ```
 
-Too use the `docker-compose.yml` file instead of `Dockerfile`, we need to adjust `devcontainer.json` with:
+To use the `docker-compose.yml` file instead of `Dockerfile`, we need to adjust `devcontainer.json` with:
 
 ```json
 {

--- a/docs/developer-experience/going-further.md
+++ b/docs/developer-experience/going-further.md
@@ -191,6 +191,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
       - "~/.ssh:/home/alex/.ssh"
     command: sleep infinity
 ```


### PR DESCRIPTION
Just a couple of small corrections I noticed. The docker-compose example was missing the `Volumes:` header, and there was a small typo.