### PR TITLE
Fix doc with invalid markdown

### DIFF
--- a/docs/resources/templates/README.md
+++ b/docs/resources/templates/README.md
@@ -3,15 +3,15 @@
 
 Description of the project
 
-# Deploying to Azure
+## Deploying to Azure
 
-# Getting started
+## Getting started
 
-# Dependencies
+## Dependencies
 
-# Run it locally
+## Run it locally
 
-#
+## Code of conduct
 
 By participating in this project, you
 agree to abide by the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

Markdown linter and search bots choke when they find multiple H1s in a single doc. Discovered in Bing Webmaster tools for the playbook:

<img width="730" alt="image" src="https://github.com/microsoft/code-with-engineering-playbook/assets/1407534/77bb5939-730e-4734-b5bb-1db523ce79b5">

##

Fixed in resources/README.md by changing extra H1s to H2s
