### PR TITLE
Fix capitalization errors in playbook navigation

### DIFF
--- a/docs/automated-testing/.pages
+++ b/docs/automated-testing/.pages
@@ -1,0 +1,6 @@
+nav:
+    - CDC testing: cdc-testing
+    - End-to-end testing: e2e-testing
+    - ...
+    - UI testing: ui-testing
+

--- a/docs/continuous-delivery/.pages
+++ b/docs/continuous-delivery/.pages
@@ -1,0 +1,5 @@
+nav:
+  - Azure DevOps: azure-devops
+  - DevOps provider recipes: devops-provider-recipes
+  - GitOps: gitops
+  - ...

--- a/docs/continuous-integration/.pages
+++ b/docs/continuous-integration/.pages
@@ -1,0 +1,5 @@
+nav:
+  - CI in data science: ci-in-data-science
+  - DevSecOps: dev-sec-ops
+  - Dev conainters: devcontainers
+  - markdown-linting

--- a/docs/design/diagram-types/.pages
+++ b/docs/design/diagram-types/.pages
@@ -1,0 +1,3 @@
+nav:
+  - Design diagram templates: DesignDiagramsTemplates
+  - ...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ theme:
 plugins:
   - search
   - git-revision-date-localized
+  - awesome-pages
 
 markdown_extensions:
   - meta

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,3 +4,5 @@ pymdown-extensions==9.4.*
 markdown==3.3.*
 mdx_truly_sane_lists==1.2
 mkdocs-git-revision-date-localized-plugin==1.0.*
+mkdocs-awesome-pages-plugin==2.9.1
+


### PR DESCRIPTION
## What are you trying to address

- Mkdocs uses the page title for the navigation label, but it can't do that for folders that don't have README.md files. In these cases, it removes dashes and underscores from folder names and applies sentence-case capitalization. This is always incorrect if the folder name uses acronyms or mixed case words.
- The result is that the EF playbook has incorrect nav labels in many spots. For example, CI/CD spelled Ci/cd or GitOps as Gitops.
- Goal is to fix capitalization errors in the mkdocs nav 

## Detailed description of all changes 

- Add awesome pages plugin, which we use in the Solutions Playbook. Powerful, reliable, and widely used
- Create .pages files in folders where there are obvious capitalization errors in the nav. 
- Note: I did not change capitalization inconsistencies that are common in the playbook. For example, most nav items use the mkdocs default sentence-casing (Only the first word is caps), but some devs have used caps in folder names resulting in partiall proper casing (All Words Are Caps).