### PR TITLE
Updates CODEOWNERSS File 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*   @skyarkitekten @chadcook @mikeholdorf
+*   @skyarkitekten @chadcook @mikeholdorf 
 
-/docs/* @skyarkitekten @chadcook @mikeholdorf
+/docs/* @skyarkitekten @chadcook @mikeholdorf @cloudappsguy @arcware @jeffblankenburg
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*   @tessferrandez @shiranr @nyouens
+*   @skyarkitekten @chadcook @mikeholdorf
 
-/docs/* @tessferrandez @shiranr @tompaana
+/docs/* @skyarkitekten @chadcook @mikeholdorf
 


### PR DESCRIPTION
# Updates CODEOWNERSS File

## Sets CODEOWNERS for Neudesic team

This repo is forked from MSFT ISE team. The old file had MSFT employees and this change re-defines for Neudesic employees
