### PR TITLE
Clarify TDD doesn't mean write *all* tests first

### DIFF
--- a/docs/automated-testing/unit-testing/README.md
+++ b/docs/automated-testing/unit-testing/README.md
@@ -97,11 +97,12 @@ An example of using dependency injection can be found [here](./authoring-example
 
 #### Test-Driven Development
 
-Test-Driven Development (TDD) is less a technique in how your code is designed, but a technique for writing your
-code that will lead you to a testable design from the start. The basic premise of test-driven development is that you
-write your test code first and then write the system under test to match the test you just wrote. This way all the test
-design is done up front and by the time you finish writing your system code, you are already at 100% test pass rate and
-test coverage. It also guarantees testable design is built into the system since the test was written first!
+Test-Driven Development (TDD) is a technique for writing your code that will lead you to a testable design from the start. 
+The basic premise of test-driven development is that you come up with a list behaviors you want your system to have.  
+You then take one behavior from the list, write the test, and then modify the system to make the test pass.  
+Then you move on to the next behavior on your list and repeat this process.
+Once you've exhausted your list, you're done!  This approach has the benefit of guaranteeing a testable design is built into 
+the system since the test was written first.
 
 For more information on TDD and an example, see the page on [Test-Driven Development](./tdd-example.md)
 


### PR DESCRIPTION
This was already written well, and the separate article `./tdd.md` is excellent. However, I think the language could be a little clearer to dispell the common misconception that TDD means you write all your tests first.  I trust this is clear to TDD practitioners, but I commonly see "senior" engineers misunderstand this.

Kent Beck sees this so commonly that he wrote a [little article](https://tidyfirst.substack.com/p/canon-tdd) on the subject.

My org was using this document for training engineers, and am hoping this small change will make it even more helpful.

I also made a minor change to the first sentence.  I understand it to be conveying one benefit of TDD, namely that it makes the code more testable, and thought it could be made more succinct.  Furthermore, many tout TDD as a mechanism for design, so explicitly negating that benefit is perhaps likely to cause unintended controversy.